### PR TITLE
Add hot root dashboard and quota-safe errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 dist/
 node_modules/
+.wrangler/
 .DS_Store

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Changed the root dashboard to `ReleaseBar Hot`, built from cached public dashboards instead of the maintainer snapshot.
+- Replaced raw GitHub rate-limit failures with dashboard-shaped quota guidance.
 - Changed the canonical public domain to `release.bar`, renamed the public dashboard to ReleaseBar, and updated the default GitHub App slug to `releasebar`.
 - Added a combined GitHub connection flow that detects GitHub App installations and prompts installation for dedicated API quota only when needed.
 - Removed the always-on GitHub App install action from the account menu and tightened account menu styling.

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Set `GITHUB_TOKEN` for higher API limits. GitHub Actions uses the built-in token
 
 ## Generic Dashboards
 
-- `/` loads the checked-in static snapshot from `data/projects.json`
+- `/` loads `ReleaseBar Hot`, a cached board built from recently requested public dashboards
 - `/:owner` loads the Worker API for that owner
 - query options: `forks=true`, `archived=true`, `unreleased=true`
 - add public sources with `owners=openclaw,steipete` or `repos=owner/name`
@@ -34,7 +34,7 @@ Set `GITHUB_TOKEN` for higher API limits. GitHub Actions uses the built-in token
 - GitHub App installation gives ReleaseBar dedicated GitHub API quota for the selected account/repositories; public dashboards still fall back to the shared server token and cache
 - private orgs still need the GitHub App installed on the target account/repositories; login alone only identifies the user
 
-The Worker in `worker/index.ts` serves both the static app shell and the generic owner API. It validates public GitHub owners, builds a capped public dashboard from the 8 most recently pushed public repos, stores it in KV, serves fresh cache for 1h, and serves stale cache while revalidating. Configure `DASHBOARD_CACHE` and `GITHUB_TOKEN` before deploying the Worker. GitHub Pages builds fall back to the workers.dev API origin while DNS is still cached away from Cloudflare.
+The Worker in `worker/index.ts` serves both the static app shell and the generic owner API. It validates public GitHub owners, builds a capped public dashboard from the 8 most recently pushed public repos, stores it in KV, serves fresh cache for 1h, serves stale cache while revalidating, and builds the root hot board from existing cached dashboards. Configure `DASHBOARD_CACHE` and `GITHUB_TOKEN` before deploying the Worker. GitHub Pages builds fall back to the workers.dev API origin while DNS is still cached away from Cloudflare.
 
 ### GitHub App Login
 

--- a/scripts/lib/dashboard.test.ts
+++ b/scripts/lib/dashboard.test.ts
@@ -18,6 +18,7 @@ import {
   workerApiOrigin,
   workersDevApiOrigin,
 } from "../../src/routing.js";
+import type { DashboardPayload, Project } from "../../src/types.js";
 import worker from "../../worker/index.js";
 
 const textEncoder = new TextEncoder();
@@ -30,6 +31,18 @@ function kvStore(initial: Record<string, string> = {}) {
     },
     async put(key: string, value: string) {
       values.set(key, value);
+    },
+    async delete(key: string) {
+      values.delete(key);
+    },
+    async list(options: { prefix?: string; limit?: number; cursor?: string } = {}) {
+      const names = [...values.keys()]
+        .filter((key) => !options.prefix || key.startsWith(options.prefix))
+        .sort();
+      return {
+        keys: names.map((name) => ({ name })),
+        list_complete: true,
+      };
     },
   };
 }
@@ -55,13 +68,87 @@ async function signedJson(secret: string, value: unknown): Promise<string> {
   return `${payload}.${base64Url(new Uint8Array(signature))}`;
 }
 
-test("owner route parsing keeps root static and owners API-backed", () => {
+function testProject(overrides: Partial<Project> & Pick<Project, "owner" | "name">): Project {
+  const { owner, name, ...rest } = overrides;
+  const fullName = `${owner}/${name}`;
+  return {
+    owner,
+    name,
+    fullName,
+    description: null,
+    url: `https://github.com/${fullName}`,
+    defaultBranch: "main",
+    language: null,
+    stars: 1,
+    forks: 0,
+    openIssues: 0,
+    openPullRequests: 0,
+    issuesUrl: `https://github.com/${fullName}/issues`,
+    pullRequestsUrl: `https://github.com/${fullName}/pulls`,
+    archived: false,
+    pushedAt: "2026-05-15T00:00:00Z",
+    updatedAt: "2026-05-15T00:00:00Z",
+    latestCommitSha: "abcdef1",
+    latestCommitDate: "2026-05-15T00:00:00Z",
+    version: "v1.0.0",
+    releaseName: null,
+    releaseUrl: `https://github.com/${fullName}/releases/tag/v1.0.0`,
+    releaseDate: "2026-05-01T00:00:00Z",
+    commitsSinceRelease: 0,
+    compareUrl: `https://github.com/${fullName}/compare/v1.0.0...main`,
+    ciState: "success",
+    ciStatus: null,
+    ciConclusion: null,
+    ciWorkflow: null,
+    ciUrl: null,
+    ciRunDate: null,
+    freshness: "fresh",
+    ...rest,
+  };
+}
+
+function testDashboard(owner: string, projects: Project[]): DashboardPayload {
+  return {
+    title: "ReleaseBar",
+    subtitle: `Release freshness for @${owner}.`,
+    canonicalDomain: "release.bar",
+    generatedAt: "2026-05-15T12:00:00Z",
+    owners: [{ type: "user", login: owner }],
+    options: {
+      includeForks: false,
+      includeArchived: false,
+      includeUnreleased: false,
+      repoLimit: 8,
+    },
+    cache: {
+      state: "fresh",
+      stale: false,
+      capped: false,
+      repoLimit: 8,
+      generatedAt: "2026-05-15T12:00:00Z",
+    },
+    totals: {
+      repos: projects.length,
+      released: projects.filter((project) => project.releaseDate).length,
+      unreleased: projects.filter((project) => !project.releaseDate).length,
+      commitsSinceRelease: projects.reduce(
+        (sum, project) => sum + (project.commitsSinceRelease ?? 0),
+        0,
+      ),
+    },
+    projects,
+  };
+}
+
+test("owner route parsing keeps root hot board and owners API-backed", () => {
   assert.equal(ownerFromPath("/"), null);
   assert.equal(ownerFromPath("/index.html"), null);
   assert.equal(ownerFromPath("/OpenClaw"), "OpenClaw");
   assert.equal(ownerFromPath("/bad_owner"), null);
 
   assert.deepEqual(dashboardRoute("/", "").isDefault, true);
+  assert.equal(dashboardRoute("/", "").apiPath, `${workerApiOrigin}/api/_hot`);
+  assert.equal(dashboardRoute("/", "").fallbackApiPath, `${workersDevApiOrigin}/api/_hot`);
   assert.equal(dashboardRoute("/openclaw", "").apiPath, `${workerApiOrigin}/api/openclaw`);
   assert.equal(
     dashboardRoute("/openclaw", "?forks=true&archived=true&unreleased=true").apiPath,
@@ -79,6 +166,180 @@ test("owner route parsing keeps root static and owners API-backed", () => {
     dashboardRoute("/", "?owners=openclaw").fallbackApiPath,
     `${workersDevApiOrigin}/api/dashboard?owners=openclaw`,
   );
+});
+
+test("worker builds root hot dashboard from cached dashboards", async () => {
+  const alphaKey = dashboardCacheKey({ owner: "alpha", schemaVersion: 1 });
+  const betaKey = dashboardCacheKey({ owner: "beta", schemaVersion: 1 });
+  const forksKey = dashboardCacheKey({ owner: "forks", includeForks: true, schemaVersion: 1 });
+  const env = {
+    DASHBOARD_CACHE: kvStore({
+      "hot:index:v1": JSON.stringify([alphaKey]),
+      [alphaKey]: JSON.stringify(
+        testDashboard("alpha", [
+          testProject({
+            owner: "alpha",
+            name: "hot",
+            commitsSinceRelease: 100,
+            freshness: "hot",
+          }),
+          testProject({ owner: "alpha", name: "second", commitsSinceRelease: 80 }),
+          testProject({ owner: "alpha", name: "third", commitsSinceRelease: 60 }),
+          testProject({ owner: "alpha", name: "fourth", commitsSinceRelease: 40 }),
+          testProject({
+            owner: "alpha",
+            name: "archived",
+            archived: true,
+            commitsSinceRelease: 120,
+          }),
+        ]),
+      ),
+      [betaKey]: JSON.stringify(
+        testDashboard("beta", [
+          testProject({
+            owner: "beta",
+            name: "popular",
+            stars: 500,
+            commitsSinceRelease: 20,
+          }),
+          testProject({
+            owner: "beta",
+            name: "unreleased",
+            releaseDate: null,
+            commitsSinceRelease: null,
+          }),
+        ]),
+      ),
+      [forksKey]: JSON.stringify({
+        ...testDashboard("forks", [
+          testProject({
+            owner: "forks",
+            name: "cached-fork",
+            commitsSinceRelease: 500,
+            freshness: "hot",
+          }),
+        ]),
+        options: {
+          includeForks: true,
+          includeArchived: false,
+          includeUnreleased: false,
+          repoLimit: 8,
+        },
+      }),
+      [dashboardCacheKey({ owner: "gamma", schemaVersion: 1 })]: JSON.stringify(
+        testDashboard("gamma", [
+          testProject({
+            owner: "gamma",
+            name: "from-list",
+            commitsSinceRelease: 30,
+          }),
+        ]),
+      ),
+    }),
+  };
+
+  const response = await worker.fetch(new Request("https://release.bar/api/_hot"), env, {
+    waitUntil: () => undefined,
+  });
+
+  assert.equal(response.status, 200);
+  const body = (await response.json()) as DashboardPayload;
+  assert.equal(body.title, "ReleaseBar Hot");
+  assert.deepEqual(body.owners, []);
+  assert.equal(body.projects[0]?.fullName, "alpha/hot");
+  assert.equal(
+    body.projects.some((project) => project.fullName === "alpha/archived"),
+    false,
+  );
+  assert.equal(
+    body.projects.some((project) => project.fullName === "beta/unreleased"),
+    false,
+  );
+  assert.equal(
+    body.projects.some((project) => project.fullName === "forks/cached-fork"),
+    false,
+  );
+  assert.equal(
+    body.projects.some((project) => project.fullName === "gamma/from-list"),
+    true,
+  );
+  assert.equal(body.projects.filter((project) => project.owner === "alpha").length <= 3, true);
+  assert.match(body.cache?.message ?? "", /cached dashboards/);
+
+  const cachedResponse = await worker.fetch(new Request("https://release.bar/api/_hot"), env, {
+    waitUntil: () => undefined,
+  });
+  const cachedBody = (await cachedResponse.json()) as DashboardPayload;
+  assert.equal(cachedBody.cache?.repoLimit, null);
+  assert.match(cachedBody.cache?.message ?? "", /cached dashboards/);
+});
+
+test("worker keeps hot owner route distinct from root hot API", async () => {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (input) => {
+    const url = new URL(String(input));
+    if (url.pathname === "/users/hot") {
+      return Response.json({ login: "hot", type: "User" });
+    }
+    if (url.pathname === "/users/hot/repos") {
+      return Response.json([]);
+    }
+    throw new Error(`unexpected fetch ${url.pathname}`);
+  };
+  try {
+    const response = await worker.fetch(
+      new Request("https://release.bar/api/hot"),
+      { DASHBOARD_CACHE: kvStore() },
+      { waitUntil: () => undefined },
+    );
+    const body = (await response.json()) as DashboardPayload;
+    assert.equal(response.status, 200);
+    assert.equal(body.owners[0]?.login, "hot");
+    assert.notEqual(body.title, "ReleaseBar Hot");
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("worker returns dashboard-shaped rate-limit errors without raw GitHub JSON", async () => {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (input) => {
+    const url = new URL(String(input));
+    if (url.pathname === "/users/vincentkoc") {
+      return Response.json(
+        {
+          message: "API rate limit exceeded for user ID 58493",
+          documentation_url: "https://docs.github.com/rest/overview/rate-limits-for-the-rest-api",
+          status: "403",
+        },
+        { status: 403 },
+      );
+    }
+    throw new Error(`unexpected fetch ${url.pathname}`);
+  };
+  const env = {
+    DASHBOARD_CACHE: kvStore(),
+    GITHUB_TOKEN: "shared-token",
+  };
+  try {
+    const response = await worker.fetch(new Request("https://release.bar/api/vincentkoc"), env, {
+      waitUntil: () => undefined,
+    });
+    assert.equal(response.status, 429);
+    const body = (await response.json()) as DashboardPayload;
+    assert.equal(body.cache?.state, "error");
+    assert.equal(body.owners[0]?.login, "vincentkoc");
+    assert.deepEqual(body.projects, []);
+    assert.match(body.cache?.message ?? "", /shared API quota is exhausted/);
+    assert.doesNotMatch(body.cache?.message ?? "", /58493|documentation_url|request ID/i);
+
+    const cached = await worker.fetch(new Request("https://release.bar/api/vincentkoc"), env, {
+      waitUntil: () => undefined,
+    });
+    assert.equal(cached.status, 429);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
 });
 
 test("worker rejects oversized custom source requests", async () => {

--- a/src/app.ts
+++ b/src/app.ts
@@ -4,12 +4,14 @@ import { dashboardRoute, validRepoSlug } from "./routing.js";
 type SortKey = "repo" | "version" | "release" | "since" | "activity" | "issues" | "prs" | "ci";
 type SortDirection = "asc" | "desc";
 
+const initialRoute = dashboardRoute(location.pathname, location.search);
+
 const state = {
   data: null as DashboardPayload | null,
   auth: null as AuthPayload | null,
   query: "",
   filter: "all" as Freshness | "all",
-  sortKey: "activity" as SortKey,
+  sortKey: (initialRoute.isDefault ? "since" : "activity") as SortKey,
   sortDirection: "desc" as SortDirection,
   devMode: localStorage.getItem("releasedeck:dev-mode") === "true",
   hiddenOwners: new Set<string>(
@@ -18,7 +20,7 @@ const state = {
   hiddenRepos: new Set<string>(
     JSON.parse(localStorage.getItem("releasedeck:hidden-repos") || "[]") as string[],
   ),
-  route: dashboardRoute(location.pathname, location.search),
+  route: initialRoute,
 };
 
 const numberFormat = new Intl.NumberFormat("en", { notation: "compact" });
@@ -67,6 +69,9 @@ function query<T extends Element>(selector: string): T {
 }
 
 function ownerLabel(data: DashboardPayload): string {
+  if (state.route.isDefault) {
+    return data.title || "ReleaseBar Hot";
+  }
   if (data.owners.length > 0) {
     const [first] = data.owners;
     const extraCount = data.owners.length - 1 + state.route.repos.length;
@@ -75,7 +80,9 @@ function ownerLabel(data: DashboardPayload): string {
   if (state.route.repos.length === 1) {
     return state.route.repos[0] ?? "custom deck";
   }
-  return state.route.repos.length > 1 ? `custom deck +${state.route.repos.length}` : "@steipete";
+  return state.route.repos.length > 1
+    ? `custom deck +${state.route.repos.length}`
+    : state.route.label;
 }
 
 function daysAgo(value: string | null): number | null {

--- a/src/index.html
+++ b/src/index.html
@@ -6,7 +6,7 @@
     <meta name="color-scheme" content="dark" />
     <meta name="description" content="Release freshness dashboard for open source maintainers." />
     <meta name="theme-color" content="#080908" />
-    <meta property="og:title" content="ReleaseBar" />
+    <meta property="og:title" content="ReleaseBar Hot" />
     <meta
       property="og:description"
       content="Release freshness across open source projects: latest versions, stale releases, commits since release, issues, PRs, and CI."
@@ -19,13 +19,13 @@
     <meta property="og:image:height" content="630" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:creator" content="@steipete" />
-    <meta name="twitter:title" content="ReleaseBar" />
+    <meta name="twitter:title" content="ReleaseBar Hot" />
     <meta
       name="twitter:description"
       content="Release freshness across open source projects: versions, stale releases, commits, issues, PRs, and CI."
     />
     <meta name="twitter:image" content="https://release.bar/og-card.png" />
-    <title>ReleaseBar</title>
+    <title>ReleaseBar Hot · ReleaseBar</title>
     <link rel="canonical" href="https://release.bar/" />
     <link rel="icon" href="/favicon.ico" sizes="any" />
     <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
@@ -37,9 +37,9 @@
       <header class="topline">
         <div>
           <p class="eyebrow">ReleaseBar</p>
-          <h1 id="dashboardTitle">@steipete</h1>
+          <h1 id="dashboardTitle">ReleaseBar Hot</h1>
           <p id="subtitle" class="subtitle">
-            Open source release freshness across steipete and OpenClaw.
+            Release debt across recently requested public dashboards.
           </p>
         </div>
         <div class="top-actions">

--- a/src/routing.ts
+++ b/src/routing.ts
@@ -79,12 +79,12 @@ export function dashboardRoute(
 
   if (!owner) {
     const custom = extraOwners.length > 0 || repos.length > 0;
-    const apiPath = custom ? `/api/dashboard${suffix}` : `./data/projects.json${suffix}`;
+    const apiPath = custom ? `/api/dashboard${suffix}` : `/api/_hot${suffix}`;
     return {
       owner: null,
-      apiPath: `${custom ? apiOrigin : ""}${apiPath}`,
-      fallbackApiPath: custom && apiOrigin === "" ? `${workersDevApiOrigin}${apiPath}` : null,
-      label: custom ? "custom deck" : "@steipete",
+      apiPath: `${apiOrigin}${apiPath}`,
+      fallbackApiPath: apiOrigin === "" ? `${workersDevApiOrigin}${apiPath}` : null,
+      label: custom ? "custom deck" : "ReleaseBar Hot",
       isDefault: !custom,
       extraOwners,
       repos,

--- a/worker/index.ts
+++ b/worker/index.ts
@@ -12,12 +12,18 @@ import type {
   AuthUser,
   DashboardPayload,
   Owner,
+  Project,
 } from "../src/types.js";
 
 type KVNamespace = {
   get(key: string): Promise<string | null>;
   put(key: string, value: string, options?: { expirationTtl?: number }): Promise<void>;
   delete?(key: string): Promise<void>;
+  list?(options?: { prefix?: string; limit?: number; cursor?: string }): Promise<{
+    keys: Array<{ name: string }>;
+    list_complete: boolean;
+    cursor?: string;
+  }>;
 };
 
 type Env = {
@@ -41,8 +47,16 @@ const fullTtlMs = 60 * 60 * 1000;
 const staleTtlSeconds = 3 * 24 * 60 * 60;
 const coldBuildWaitMs = 15 * 1000;
 const repoLimit = 8;
+const hotLimit = 50;
+const hotOwnerLimit = 3;
+const hotSourceLimit = 24;
+const hotIndexLimit = 100;
+const hotCacheTtlMs = 5 * 60 * 1000;
 const maxCustomSources = 8;
 const schemaVersion = 1;
+const dashboardCachePrefix = `dashboard:v${schemaVersion}:`;
+const hotCacheKey = `hot:v${schemaVersion}`;
+const hotIndexKey = `hot:index:v${schemaVersion}`;
 const sessionCookie = "rd_session";
 const installReturnCookie = "rd_install_return";
 const sessionMaxAgeSeconds = 30 * 24 * 60 * 60;
@@ -411,7 +425,7 @@ function socialLabel(url: URL): string {
   if (repos.length === 1) {
     return repos[0] ?? "custom deck";
   }
-  return repos.length > 1 ? `custom deck +${repos.length}` : "@steipete";
+  return repos.length > 1 ? `custom deck +${repos.length}` : "ReleaseBar Hot";
 }
 
 function socialImage(label: string): Response {
@@ -996,15 +1010,16 @@ function withCacheState(
   state: NonNullable<DashboardPayload["cache"]>["state"],
   message?: string,
 ): DashboardPayload {
+  const cacheMessage = message ?? payload.cache?.message;
   return {
     ...payload,
     cache: {
       state,
       stale: state !== "fresh",
       capped: payload.cache?.capped ?? false,
-      repoLimit: payload.cache?.repoLimit ?? repoLimit,
+      repoLimit: payload.cache ? payload.cache.repoLimit : repoLimit,
       generatedAt: payload.generatedAt,
-      ...(message ? { message } : {}),
+      ...(cacheMessage ? { message: cacheMessage } : {}),
     },
   };
 }
@@ -1015,6 +1030,33 @@ function optionsFromUrl(url: URL) {
     includeArchived: url.searchParams.get("archived") === "true",
     includeUnreleased: url.searchParams.get("unreleased") === "true",
   };
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function isGitHubRateLimit(error: unknown): boolean {
+  return /rate limit|secondary rate|api rate limit exceeded|shared api quota|quota .*exhausted/i.test(
+    errorMessage(error),
+  );
+}
+
+function dashboardErrorMessage(error: unknown): string {
+  if (isGitHubRateLimit(error)) {
+    return "GitHub shared API quota is exhausted. Connect GitHub and install the app for this account to use dedicated quota, or try again after the shared quota resets.";
+  }
+
+  const message = errorMessage(error);
+  const githubMatch = message.match(/^GitHub API (\d+) for ([^:]+):/);
+  if (githubMatch) {
+    return `GitHub API ${githubMatch[1]} while loading ${githubMatch[2]}.`;
+  }
+  return message;
+}
+
+function errorStatus(error: unknown): number {
+  return isGitHubRateLimit(error) ? 429 : 502;
 }
 
 async function readCached(env: Env, key: string): Promise<DashboardPayload | null> {
@@ -1031,6 +1073,167 @@ async function writeCached(
   await env.DASHBOARD_CACHE?.put(key, JSON.stringify(payload), {
     expirationTtl: ttlSeconds,
   });
+}
+
+function projectActivityDate(project: Project): string | null {
+  return project.latestCommitDate || project.pushedAt || project.updatedAt;
+}
+
+function daysSince(value: string | null): number | null {
+  if (!value) return null;
+  const time = Date.parse(value);
+  if (Number.isNaN(time)) return null;
+  return Math.max(0, Math.round((Date.now() - time) / 86400000));
+}
+
+function hotScore(project: Project): number {
+  const commits = project.commitsSinceRelease ?? 0;
+  const stars = Math.log1p(project.stars) * 6;
+  const activityDays = daysSince(projectActivityDate(project));
+  const recency =
+    activityDays === null ? 0 : (Math.max(0, 30 - Math.min(activityDays, 30)) / 30) * 20;
+  const prs = Math.log1p(project.openPullRequests) * 2;
+  const ci = project.ciState === "failure" ? 15 : project.ciState === "running" ? 5 : 0;
+  return commits * 4 + stars + recency + prs + ci;
+}
+
+async function readCachedDashboards(env: Env): Promise<DashboardPayload[]> {
+  if (!env.DASHBOARD_CACHE) return [];
+
+  const dashboards: DashboardPayload[] = [];
+  let keys = await readHotIndex(env);
+  if (keys.length < hotSourceLimit && env.DASHBOARD_CACHE.list) {
+    const page = await env.DASHBOARD_CACHE.list({
+      prefix: dashboardCachePrefix,
+      limit: hotSourceLimit,
+    });
+    keys = [...new Set([...keys, ...page.keys.map((key) => key.name)])];
+  }
+
+  for (const key of keys.slice(0, hotSourceLimit)) {
+    const raw = await env.DASHBOARD_CACHE.get(key);
+    if (!raw) continue;
+    try {
+      const payload = JSON.parse(raw) as DashboardPayload;
+      if (
+        payload.cache?.state === "error" ||
+        payload.options?.includeForks ||
+        payload.projects.length === 0
+      ) {
+        continue;
+      }
+      dashboards.push(payload);
+    } catch {
+      continue;
+    }
+  }
+
+  return dashboards;
+}
+
+async function readHotIndex(env: Env): Promise<string[]> {
+  const raw = await env.DASHBOARD_CACHE?.get(hotIndexKey);
+  if (!raw) return [];
+  try {
+    const keys = JSON.parse(raw) as unknown;
+    return Array.isArray(keys)
+      ? keys.filter(
+          (key): key is string => typeof key === "string" && key.startsWith(dashboardCachePrefix),
+        )
+      : [];
+  } catch {
+    return [];
+  }
+}
+
+async function rememberHotDashboard(
+  env: Env,
+  key: string,
+  payload: DashboardPayload,
+): Promise<void> {
+  if (payload.options?.includeForks) return;
+  const keys = await readHotIndex(env);
+  const next = [key, ...keys.filter((existing) => existing !== key)].slice(0, hotIndexLimit);
+  await env.DASHBOARD_CACHE?.put(hotIndexKey, JSON.stringify(next), {
+    expirationTtl: staleTtlSeconds,
+  });
+}
+
+function hotDashboardPayload(
+  dashboards: DashboardPayload[],
+  env: Env,
+  generatedAt = new Date().toISOString(),
+): DashboardPayload {
+  const candidates = new Map<string, Project>();
+  for (const dashboard of dashboards) {
+    for (const project of dashboard.projects) {
+      if (project.archived || !project.releaseDate || project.commitsSinceRelease === null) {
+        continue;
+      }
+      const existing = candidates.get(project.fullName.toLowerCase());
+      if (!existing || hotScore(project) > hotScore(existing)) {
+        candidates.set(project.fullName.toLowerCase(), project);
+      }
+    }
+  }
+
+  const ownerCounts = new Map<string, number>();
+  const projects = [...candidates.values()]
+    .sort((a, b) => hotScore(b) - hotScore(a))
+    .filter((project) => {
+      const owner = project.owner.toLowerCase();
+      const count = ownerCounts.get(owner) ?? 0;
+      if (count >= hotOwnerLimit) return false;
+      ownerCounts.set(owner, count + 1);
+      return true;
+    })
+    .slice(0, hotLimit);
+  const totalCommits = projects.reduce(
+    (sum, project) => sum + (project.commitsSinceRelease ?? 0),
+    0,
+  );
+  const omitted = candidates.size > projects.length;
+
+  return {
+    title: "ReleaseBar Hot",
+    subtitle: "Release debt across recently requested public dashboards.",
+    canonicalDomain: env.RELEASEDECK_CANONICAL_DOMAIN ?? "release.bar",
+    generatedAt,
+    owners: [],
+    options: {
+      includeForks: false,
+      includeArchived: false,
+      includeUnreleased: false,
+      repoLimit: null,
+    },
+    cache: {
+      state: "fresh",
+      stale: false,
+      capped: omitted,
+      repoLimit: null,
+      generatedAt,
+      message: `built from ${dashboards.length} cached dashboard${dashboards.length === 1 ? "" : "s"}`,
+    },
+    totals: {
+      repos: projects.length,
+      released: projects.filter((project) => project.releaseDate).length,
+      unreleased: projects.filter((project) => !project.releaseDate).length,
+      commitsSinceRelease: totalCommits,
+    },
+    projects,
+  };
+}
+
+async function hotResponse(env: Env): Promise<Response> {
+  const cached = await readCached(env, hotCacheKey);
+  const ageMs = cached ? Date.now() - Date.parse(cached.generatedAt) : Number.POSITIVE_INFINITY;
+  if (cached && ageMs < hotCacheTtlMs) {
+    return jsonResponse(withCacheState(cached, "fresh"));
+  }
+
+  const payload = hotDashboardPayload(await readCachedDashboards(env), env);
+  await writeCached(env, hotCacheKey, payload);
+  return jsonResponse(payload);
 }
 
 async function rebuild(dashboard: DashboardRequest, env: Env): Promise<DashboardPayload> {
@@ -1052,6 +1255,7 @@ async function rebuild(dashboard: DashboardRequest, env: Env): Promise<Dashboard
       fetch: workerFetch,
     });
     await writeCached(env, dashboard.key, payload);
+    await rememberHotDashboard(env, dashboard.key, payload);
     return payload;
   })();
 
@@ -1067,6 +1271,20 @@ function errorPayload(dashboard: DashboardRequest, env: Env, message: string): D
   return statusPayload(dashboard, env, "error", message, new Date().toISOString());
 }
 
+function unresolvedDashboardRequest(
+  ownerSlugs: string[],
+  includeRepos: string[],
+  key: string,
+  url: URL,
+): DashboardRequest {
+  return dashboardRequest(
+    ownerSlugs.map((login) => ({ type: "user", login })),
+    includeRepos,
+    key,
+    url,
+  );
+}
+
 function rebuildingPayload(dashboard: DashboardRequest, env: Env): DashboardPayload {
   return statusPayload(
     dashboard,
@@ -1078,8 +1296,12 @@ function rebuildingPayload(dashboard: DashboardRequest, env: Env): DashboardPayl
 }
 
 function cacheBuildError(dashboard: DashboardRequest, env: Env, error: unknown): Promise<void> {
-  const message = error instanceof Error ? error.message : String(error);
-  return writeCached(env, dashboard.key, errorPayload(dashboard, env, message), 5 * 60);
+  return writeCached(
+    env,
+    dashboard.key,
+    errorPayload(dashboard, env, dashboardErrorMessage(error)),
+    5 * 60,
+  );
 }
 
 function statusPayload(
@@ -1162,7 +1384,7 @@ async function ownerResponse(
           return rebuild(dashboard, env).catch((error) => cacheBuildError(dashboard, env, error));
         }),
     );
-    return jsonResponse(cached, 502, {
+    return jsonResponse(cached, errorStatus(cached.cache.message ?? ""), {
       "cache-control": "no-store",
     });
   }
@@ -1188,7 +1410,10 @@ async function ownerResponse(
   try {
     owners = await resolveOwners(ownerSlugs, env, token);
   } catch (error) {
-    return jsonResponse({ error: error instanceof Error ? error.message : String(error) }, 502, {
+    const dashboard = unresolvedDashboardRequest(ownerSlugs, includeRepos, key, url);
+    const payload = errorPayload(dashboard, env, dashboardErrorMessage(error));
+    await writeCached(env, key, payload, 5 * 60);
+    return jsonResponse(payload, errorStatus(error), {
       "cache-control": "no-store",
     });
   }
@@ -1215,13 +1440,9 @@ async function ownerResponse(
     }
     return jsonResponse(payload);
   } catch (error) {
-    const payload = errorPayload(
-      dashboard,
-      env,
-      error instanceof Error ? error.message : String(error),
-    );
+    const payload = errorPayload(dashboard, env, dashboardErrorMessage(error));
     await writeCached(env, key, payload, 5 * 60);
-    return jsonResponse(payload, 502, {
+    return jsonResponse(payload, errorStatus(error), {
       "cache-control": "no-store",
     });
   }
@@ -1293,6 +1514,9 @@ async function routeRequest(
   }
   if (url.pathname.startsWith("/api/auth/")) {
     return authResponse(request, env);
+  }
+  if (url.pathname === "/api/_hot") {
+    return hotResponse(env);
   }
   if (url.pathname.startsWith("/api/")) {
     return ownerResponse(request, env, context);


### PR DESCRIPTION
## Summary
- make `/` load `ReleaseBar Hot` from cached public dashboards instead of the old maintainer snapshot
- add Worker hot aggregation with bounded KV reads and owner diversity
- sanitize GitHub rate-limit failures into dashboard-shaped 429 responses with GitHub App quota guidance

## Verification
- npm run format
- npm run check:static
- codex-review --full-access
