### PR TITLE
feat: expose GitHub quota status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Exposed GitHub API quota source, remaining calls, and reset time in dashboard cache status.
 - Reduced GitHub API fanout with GraphQL repository metadata, KV-backed repo fragments, and Durable Object rebuild locking.
 - Made repository language tags clickable filters and exposed language filters in the command palette.
 - Added a dedicated loading state while empty dashboards are still being fetched and cached.

--- a/scripts/lib/dashboard.test.ts
+++ b/scripts/lib/dashboard.test.ts
@@ -423,6 +423,85 @@ test("worker returns dashboard-shaped rate-limit errors without raw GitHub JSON"
   }
 });
 
+test("dashboard build records GitHub quota headers", async () => {
+  const resetAt = Math.floor(Date.parse("2026-05-15T13:00:00Z") / 1000);
+  const payload = await buildDashboard({
+    title: "ReleaseBar",
+    subtitle: "test",
+    canonicalDomain: "example.com",
+    owners: [{ type: "user", login: "owner" }],
+    includeForks: false,
+    includeArchived: false,
+    token: "installation-token",
+    quotaSource: "app",
+    quotaAccount: "owner",
+    repoLimit: 200,
+    fetch: async (url) => {
+      const path = new URL(String(url)).pathname;
+      if (path === "/graphql") {
+        return Response.json(
+          {
+            data: {
+              repositoryOwner: {
+                __typename: "User",
+                repositories: {
+                  pageInfo: { hasNextPage: false, endCursor: null },
+                  nodes: [],
+                },
+              },
+            },
+          },
+          {
+            headers: {
+              "x-ratelimit-limit": "5000",
+              "x-ratelimit-remaining": "4998",
+              "x-ratelimit-reset": String(resetAt),
+              "x-ratelimit-resource": "graphql",
+            },
+          },
+        );
+      }
+      throw new Error(`unexpected fetch ${path}`);
+    },
+  });
+
+  assert.equal(payload.cache?.quota?.source, "app");
+  assert.equal(payload.cache?.quota?.account, "owner");
+  assert.equal(payload.cache?.quota?.limit, 5000);
+  assert.equal(payload.cache?.quota?.remaining, 4998);
+  assert.equal(payload.cache?.quota?.resetAt, "2026-05-15T13:00:00.000Z");
+  assert.equal(payload.cache?.quota?.resource, "graphql");
+});
+
+test("worker preserves cached quota metadata on fresh responses", async () => {
+  const key = dashboardCacheKey({ owner: "owner", schemaVersion: 2 });
+  const dashboard = testDashboard("owner", []);
+  dashboard.generatedAt = new Date().toISOString();
+  if (dashboard.cache) {
+    dashboard.cache.generatedAt = dashboard.generatedAt;
+    dashboard.cache.quota = {
+      source: "app",
+      account: "owner",
+      limit: 5000,
+      remaining: 4900,
+      resetAt: "2026-05-15T13:00:00.000Z",
+      resource: "graphql",
+    };
+  }
+
+  const response = await worker.fetch(
+    new Request("https://release.bar/api/owner"),
+    { DASHBOARD_CACHE: kvStore({ [key]: JSON.stringify(dashboard) }) },
+    { waitUntil: () => undefined },
+  );
+
+  assert.equal(response.status, 200);
+  const body = (await response.json()) as DashboardPayload;
+  assert.equal(body.cache?.state, "fresh");
+  assert.equal(body.cache?.quota?.source, "app");
+  assert.equal(body.cache?.quota?.remaining, 4900);
+});
+
 test("worker returns rebuilding while another isolate owns the dashboard build lock", async () => {
   const originalFetch = globalThis.fetch;
   let repoFetches = 0;
@@ -913,17 +992,27 @@ test("worker uses GitHub App installation token for cold owner dashboards", asyn
     }
     if (url.pathname === "/graphql") {
       assert.equal(authorization, "Bearer installation-token");
-      return Response.json({
-        data: {
-          repositoryOwner: {
-            __typename: "Organization",
-            repositories: {
-              pageInfo: { hasNextPage: false, endCursor: null },
-              nodes: [],
+      return Response.json(
+        {
+          data: {
+            repositoryOwner: {
+              __typename: "Organization",
+              repositories: {
+                pageInfo: { hasNextPage: false, endCursor: null },
+                nodes: [],
+              },
             },
           },
         },
-      });
+        {
+          headers: {
+            "x-ratelimit-limit": "5000",
+            "x-ratelimit-remaining": "4997",
+            "x-ratelimit-reset": String(Math.floor(Date.parse("2026-05-15T13:00:00Z") / 1000)),
+            "x-ratelimit-resource": "graphql",
+          },
+        },
+      );
     }
     throw new Error(`unexpected fetch ${url.pathname}`);
   };
@@ -937,6 +1026,10 @@ test("worker uses GitHub App installation token for cold owner dashboards", asyn
     );
     assert.equal(response.status, 200);
     assert.equal(ownerResolvedWithInstallationToken, true);
+    const body = (await response.json()) as DashboardPayload;
+    assert.equal(body.cache?.quota?.source, "app");
+    assert.equal(body.cache?.quota?.account, "openclaw");
+    assert.equal(body.cache?.quota?.remaining, 4997);
   } finally {
     globalThis.fetch = originalFetch;
   }

--- a/scripts/lib/dashboard.ts
+++ b/scripts/lib/dashboard.ts
@@ -1,4 +1,5 @@
 import type {
+  ApiQuota,
   CiState,
   DashboardPayload,
   Freshness,
@@ -19,6 +20,8 @@ export type DashboardBuildOptions = {
   includeRepos?: string[];
   repoLimit?: number;
   token?: string;
+  quotaSource?: ApiQuota["source"];
+  quotaAccount?: string | null;
   fetch?: typeof fetch;
   projectCache?: ProjectCache;
   log?: (message: string) => void;
@@ -103,6 +106,7 @@ type GitHubClient = {
   fetch: typeof fetch;
   headers: Record<string, string>;
   graphqlCursors: Map<string, Array<string | null | undefined>>;
+  quota: ApiQuota;
 };
 
 type GraphQLRepoNode = {
@@ -196,6 +200,40 @@ function rateLimitFromResponse(response: Response, pathname: string): GitHubRate
   );
 }
 
+function numberHeader(headers: Headers, name: string): number | null {
+  const value = headers.get(name);
+  if (value === null) return null;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function resetAtHeader(headers: Headers): string | null {
+  const reset = numberHeader(headers, "x-ratelimit-reset");
+  return reset === null ? null : new Date(reset * 1000).toISOString();
+}
+
+function recordRateLimit(client: GitHubClient, response: Response): void {
+  const limit = numberHeader(response.headers, "x-ratelimit-limit");
+  const remaining = numberHeader(response.headers, "x-ratelimit-remaining");
+  const resetAt = resetAtHeader(response.headers);
+  const resource = response.headers.get("x-ratelimit-resource");
+  if (limit === null && remaining === null && resetAt === null && resource === null) {
+    return;
+  }
+
+  const replaceBucket =
+    remaining !== null && (client.quota.remaining === null || remaining <= client.quota.remaining);
+  client.quota = {
+    ...client.quota,
+    limit: replaceBucket ? (limit ?? client.quota.limit) : (client.quota.limit ?? limit),
+    remaining: replaceBucket ? remaining : client.quota.remaining,
+    resetAt: replaceBucket ? (resetAt ?? client.quota.resetAt) : (client.quota.resetAt ?? resetAt),
+    resource: replaceBucket
+      ? (resource ?? client.quota.resource)
+      : (client.quota.resource ?? resource),
+  };
+}
+
 export function normalizeBuildOptions(
   config: ReleaseBarConfig,
   overrides: Partial<DashboardBuildOptions> = {},
@@ -284,7 +322,12 @@ export function freshness(project: Pick<Project, "commitsSinceRelease">): Freshn
   return "hot";
 }
 
-function githubClient(token = "", fetcher: typeof fetch = fetch): GitHubClient {
+function githubClient(
+  token = "",
+  fetcher: typeof fetch = fetch,
+  quotaSource: ApiQuota["source"] = token ? "shared" : "anonymous",
+  quotaAccount: string | null = null,
+): GitHubClient {
   const headers: Record<string, string> = {
     Accept: "application/vnd.github+json",
     "User-Agent": "ReleaseBar",
@@ -295,7 +338,19 @@ function githubClient(token = "", fetcher: typeof fetch = fetch): GitHubClient {
     headers.Authorization = `Bearer ${token}`;
   }
 
-  return { fetch: fetcher, headers, graphqlCursors: new Map() };
+  return {
+    fetch: fetcher,
+    headers,
+    graphqlCursors: new Map(),
+    quota: {
+      source: quotaSource,
+      account: quotaAccount,
+      remaining: null,
+      limit: null,
+      resetAt: null,
+      resource: null,
+    },
+  };
 }
 
 async function github<T>(
@@ -306,6 +361,7 @@ async function github<T>(
   const response = await client.fetch(`https://api.github.com${pathname}`, {
     headers: client.headers,
   });
+  recordRateLimit(client, response);
   const rateLimit = rateLimitFromResponse(response, pathname);
   if (rateLimit) throw rateLimit;
   if (ignoreStatuses.includes(response.status)) {
@@ -356,6 +412,7 @@ async function githubGraphql<T>(
     },
     body: JSON.stringify({ query, variables }),
   });
+  recordRateLimit(client, response);
   const rateLimit = rateLimitFromResponse(response, "/graphql");
   if (rateLimit) throw rateLimit;
   if (!response.ok) {
@@ -502,6 +559,7 @@ async function githubCount(client: GitHubClient, pathname: string): Promise<numb
   const response = await client.fetch(`https://api.github.com${pathname}${joiner}per_page=1`, {
     headers: client.headers,
   });
+  recordRateLimit(client, response);
   if (response.status === 404) {
     return 0;
   }
@@ -751,7 +809,12 @@ export async function resolveOwnerType(
 }
 
 export async function buildDashboard(options: DashboardBuildOptions): Promise<DashboardPayload> {
-  const client = githubClient(options.token, options.fetch);
+  const client = githubClient(
+    options.token,
+    options.fetch,
+    options.quotaSource,
+    options.quotaAccount ?? null,
+  );
   const projects: Project[] = [];
   let capped = false;
   const seen = new Set<string>();
@@ -854,6 +917,7 @@ export async function buildDashboard(options: DashboardBuildOptions): Promise<Da
       capped,
       repoLimit: options.repoLimit ?? null,
       generatedAt,
+      quota: client.quota,
     },
     totals: {
       repos: projects.length,

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -25,7 +25,7 @@
     type SortKey,
   } from "./dashboard-view.js";
   import { dashboardRoute, validRepoSlug } from "./routing.js";
-  import type { AuthPayload, DashboardPayload, Project } from "./types.js";
+  import type { ApiQuota, AuthPayload, DashboardPayload, Project } from "./types.js";
 
   const initialRoute = dashboardRoute(location.pathname, location.search);
   const storedDevMode = localStorage.getItem("releasedeck:dev-mode") === "true";
@@ -60,6 +60,10 @@
     month: "short",
     day: "numeric",
     year: "numeric",
+  });
+  const timeFormat = new Intl.DateTimeFormat("en", {
+    hour: "numeric",
+    minute: "2-digit",
   });
   const relativeFormat = new Intl.RelativeTimeFormat("en", { numeric: "auto" });
 
@@ -158,6 +162,19 @@
     const months = Math.round(days / 30);
     if (Math.abs(months) < 18) return relativeFormat.format(months, "month");
     return relativeFormat.format(Math.round(months / 12), "year");
+  }
+
+  function relativeReset(value: string): string {
+    const time = Date.parse(value);
+    if (Number.isNaN(time)) return "";
+    const diffMs = time - Date.now();
+    if (Math.abs(diffMs) < 90 * 60 * 1000) {
+      return relativeFormat.format(Math.round(diffMs / 60000), "minute");
+    }
+    if (Math.abs(diffMs) < 36 * 60 * 60 * 1000) {
+      return `${relativeFormat.format(Math.round(diffMs / 3600000), "hour")} at ${timeFormat.format(new Date(time))}`;
+    }
+    return `${absoluteDate(value)} at ${timeFormat.format(new Date(time))}`;
   }
 
   function matchesBase(
@@ -332,6 +349,21 @@
     return project.ciState;
   }
 
+  function quotaLabel(quota: ApiQuota | undefined): string {
+    if (!quota) return "";
+    const source =
+      quota.source === "app"
+        ? `app quota${quota.account ? ` @${quota.account}` : ""}`
+        : quota.source === "shared"
+          ? "shared quota"
+          : "anonymous quota";
+    const remaining =
+      quota.remaining === null ? "" : `${numberFormat.format(quota.remaining)} left`;
+    const resetAt = quota.resetAt ? relativeReset(quota.resetAt) : "";
+    const reset = resetAt ? `reset ${resetAt}` : "";
+    return [source, remaining, reset].filter(Boolean).join(" · ");
+  }
+
   function updateStatus(): void {
     if (!data) return;
     const cacheState = data.cache?.state;
@@ -339,7 +371,8 @@
     const capped = data.cache?.capped
       ? ` · capped at ${numberFormat.format(data.cache.repoLimit ?? data.projects.length)}`
       : "";
-    generatedLabel = `updated ${relativeDate(data.generatedAt)}${cacheState ? ` · ${cacheState}` : ""}${stale}${capped}`;
+    const quota = quotaLabel(data.cache?.quota);
+    generatedLabel = `updated ${relativeDate(data.generatedAt)}${cacheState ? ` · ${cacheState}` : ""}${stale}${capped}${quota ? ` · ${quota}` : ""}`;
   }
 
   async function fetchPayload(apiPath: string): Promise<Response> {

--- a/src/types.ts
+++ b/src/types.ts
@@ -91,6 +91,15 @@ export type AuthPayload = {
   appUrl: string;
 };
 
+export type ApiQuota = {
+  source: "app" | "shared" | "anonymous";
+  account: string | null;
+  remaining: number | null;
+  limit: number | null;
+  resetAt: string | null;
+  resource: string | null;
+};
+
 export type DashboardPayload = {
   title: string;
   subtitle: string;
@@ -109,6 +118,7 @@ export type DashboardPayload = {
     capped: boolean;
     repoLimit: number | null;
     generatedAt: string;
+    quota?: ApiQuota;
     message?: string;
   };
   totals: {

--- a/worker/index.ts
+++ b/worker/index.ts
@@ -22,6 +22,7 @@ import {
   type GitHubInstallationRepository,
 } from "./schemas.js";
 import type {
+  ApiQuota,
   AuthInstallation,
   AuthPayload,
   AuthUser,
@@ -115,6 +116,14 @@ type DashboardRequest = {
   key: string;
   url: URL;
   token?: string;
+  quotaSource?: ApiQuota["source"];
+  quotaAccount?: string | null;
+};
+
+type RequestToken = {
+  token: string;
+  quotaSource: "app";
+  quotaAccount: string | null;
 };
 
 type BuildLock = {
@@ -836,13 +845,20 @@ async function requestInstallationToken(
   request: Request,
   env: Env,
   sources: TokenSources,
-): Promise<string | null> {
+): Promise<RequestToken | null> {
   if (!appTokenConfigured(env)) return null;
   const session = await currentSession(request, env);
   if (!session) return null;
   const installations = await githubInstallations(session.accessToken);
   const installation = matchingInstallation(installations, sources);
-  return installation ? cachedInstallationToken(env, installation.id) : null;
+  const token = installation ? await cachedInstallationToken(env, installation.id) : null;
+  return token
+    ? {
+        token,
+        quotaSource: "app",
+        quotaAccount: installation?.accountLogin ?? null,
+      }
+    : null;
 }
 
 function sourceAccounts(sources: TokenSources): string[] {
@@ -1063,8 +1079,20 @@ function withCacheState(
       capped: payload.cache?.capped ?? false,
       repoLimit: payload.cache ? payload.cache.repoLimit : repoLimit,
       generatedAt: payload.generatedAt,
+      ...(payload.cache?.quota ? { quota: payload.cache.quota } : {}),
       ...(cacheMessage ? { message: cacheMessage } : {}),
     },
+  };
+}
+
+function quotaForDashboard(dashboard: DashboardRequest, env: Env): ApiQuota {
+  return {
+    source: dashboard.quotaSource ?? (dashboard.token || env.GITHUB_TOKEN ? "shared" : "anonymous"),
+    account: dashboard.quotaAccount ?? null,
+    remaining: null,
+    limit: null,
+    resetAt: null,
+    resource: null,
   };
 }
 
@@ -1347,6 +1375,9 @@ async function rebuild(dashboard: DashboardRequest, env: Env): Promise<Dashboard
       ...optionsFromUrl(dashboard.url),
       repoLimit,
       token: dashboard.token ?? env.GITHUB_TOKEN,
+      quotaSource:
+        dashboard.quotaSource ?? (dashboard.token || env.GITHUB_TOKEN ? "shared" : "anonymous"),
+      quotaAccount: dashboard.quotaAccount ?? null,
       fetch: workerFetch,
       projectCache: env.DASHBOARD_CACHE,
     });
@@ -1392,12 +1423,14 @@ function unresolvedDashboardRequest(
   includeRepos: string[],
   key: string,
   url: URL,
+  token?: RequestToken | null,
 ): DashboardRequest {
   return dashboardRequest(
     ownerSlugs.map((login) => ({ type: "user", login })),
     includeRepos,
     key,
     url,
+    token,
   );
 }
 
@@ -1443,6 +1476,7 @@ function statusPayload(
       capped: false,
       repoLimit,
       generatedAt,
+      quota: quotaForDashboard(dashboard, env),
       message,
     },
     totals: {
@@ -1526,9 +1560,9 @@ async function ownerResponse(
   const token = await requestToken().catch(() => null);
   let owners: Owner[] | null;
   try {
-    owners = await resolveOwners(ownerSlugs, env, token);
+    owners = await resolveOwners(ownerSlugs, env, token?.token);
   } catch (error) {
-    const dashboard = unresolvedDashboardRequest(ownerSlugs, includeRepos, key, url);
+    const dashboard = unresolvedDashboardRequest(ownerSlugs, includeRepos, key, url, token);
     const payload = errorPayload(dashboard, env, dashboardErrorMessage(error));
     await writeCached(env, key, payload, 5 * 60);
     return jsonResponse(payload, errorStatus(error), retryAfterHeaders(error));
@@ -1567,7 +1601,7 @@ function cachedDashboardRequest(
   includeRepos: string[],
   key: string,
   url: URL,
-  token?: string | null,
+  token?: RequestToken | null,
 ): DashboardRequest {
   return dashboardRequest(payload.owners, includeRepos, key, url, token);
 }
@@ -1577,7 +1611,7 @@ function dashboardRequest(
   includeRepos: string[],
   key: string,
   url: URL,
-  token?: string | null,
+  token?: RequestToken | null,
 ): DashboardRequest {
   return {
     owners,
@@ -1585,7 +1619,13 @@ function dashboardRequest(
     subtitle: dashboardSubtitle(owners, includeRepos),
     key,
     url,
-    ...(token ? { token } : {}),
+    ...(token
+      ? {
+          token: token.token,
+          quotaSource: token.quotaSource,
+          quotaAccount: token.quotaAccount,
+        }
+      : {}),
   };
 }
 


### PR DESCRIPTION
## Summary
- record GitHub REST/GraphQL rate-limit headers in dashboard cache metadata
- tag dashboard builds as app/shared/anonymous quota and preserve that through fresh/stale/error states
- show quota source, remaining calls, and time-aware reset text in the header status

## Proof
- `npm run check:static`
- `/Users/steipete/Projects/agent-scripts/skills/codex-review/scripts/codex-review --parallel-tests "npm run check:static"`
- codex-review clean: no accepted/actionable findings reported
