### PR TITLE
feat: add GitHub Hot discovery dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Added a GitHub Hot root dashboard backed by cached GitHub repository search, with today/week/month/year and language filters.
 - Made project owners link to their ReleaseBar dashboards while repository names still open GitHub.
 - Show cached partial source data while cold combined dashboards rebuild in the background.
 - Added owner-only public dashboard defaults so saved sources and visibility apply at clean owner URLs.

--- a/scripts/lib/dashboard.test.ts
+++ b/scripts/lib/dashboard.test.ts
@@ -156,8 +156,21 @@ test("owner route parsing keeps root hot board and owners API-backed", () => {
   assert.equal(ownerDashboardPath("@Steipete"), "/steipete");
 
   assert.deepEqual(dashboardRoute("/", "").isDefault, true);
-  assert.equal(dashboardRoute("/", "").apiPath, `${workerApiOrigin}/api/_hot`);
-  assert.equal(dashboardRoute("/", "").fallbackApiPath, `${workersDevApiOrigin}/api/_hot`);
+  assert.equal(dashboardRoute("/", "").apiPath, `${workerApiOrigin}/api/_discover`);
+  assert.equal(dashboardRoute("/", "").fallbackApiPath, `${workersDevApiOrigin}/api/_discover`);
+  assert.equal(dashboardRoute("/", "").discoverPeriod, "week");
+  assert.equal(
+    dashboardRoute("/", "?period=day&hotLang=TypeScript").apiPath,
+    `${workerApiOrigin}/api/_discover?period=day&lang=TypeScript`,
+  );
+  assert.equal(
+    dashboardRoute("/", "?period=releasebar&hotLang=TypeScript").apiPath,
+    `${workerApiOrigin}/api/_hot`,
+  );
+  assert.equal(
+    dashboardRoute("/", "?period=day&lang=TypeScript").apiPath,
+    `${workerApiOrigin}/api/_discover?period=day`,
+  );
   assert.equal(dashboardRoute("/openclaw", "").apiPath, `${workerApiOrigin}/api/openclaw`);
   assert.equal(
     dashboardRoute("/openclaw", "?forks=true&archived=true&unreleased=true").apiPath,
@@ -231,6 +244,21 @@ test("dashboard view state restores search, filters, sorting, and dev columns", 
       false,
     ),
     "?owners=openclaw",
+  );
+  assert.equal(
+    viewStateSearch(
+      "?period=day&hotLang=TypeScript&lang=Swift",
+      {
+        query: "",
+        language: "",
+        filter: "all",
+        sortKey: "activity",
+        sortDirection: "desc",
+        devMode: false,
+      },
+      false,
+    ),
+    "?period=day&hotLang=TypeScript",
   );
 });
 
@@ -379,6 +407,125 @@ test("worker keeps hot owner route distinct from root hot API", async () => {
     assert.equal(response.status, 200);
     assert.equal(body.owners[0]?.login, "hot");
     assert.notEqual(body.title, "ReleaseBar Hot");
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("worker serves cached GitHub discovery dashboards from repository search", async () => {
+  const originalFetch = globalThis.fetch;
+  let calls = 0;
+  globalThis.fetch = async (input, init) => {
+    calls += 1;
+    const url = new URL(String(input));
+    assert.equal(url.pathname, "/search/repositories");
+    assert.match(url.searchParams.get("q") ?? "", /language:"TypeScript"/);
+    assert.match(url.searchParams.get("q") ?? "", /pushed:>=/);
+    assert.equal(url.searchParams.get("sort"), "stars");
+    assert.equal((init?.headers as Record<string, string>)?.authorization, "Bearer shared-token");
+    return Response.json(
+      {
+        total_count: 2,
+        incomplete_results: false,
+        items: [
+          {
+            name: "releasebar",
+            full_name: "acme/releasebar",
+            private: false,
+            fork: false,
+            archived: false,
+            html_url: "https://github.com/acme/releasebar",
+            description: "Release dashboard",
+            default_branch: "main",
+            language: "TypeScript",
+            stargazers_count: 1200,
+            forks_count: 42,
+            open_issues_count: 7,
+            pushed_at: "2026-05-16T12:00:00Z",
+            updated_at: "2026-05-16T12:00:00Z",
+            owner: { login: "acme" },
+          },
+        ],
+      },
+      {
+        headers: {
+          "x-ratelimit-remaining": "4999",
+          "x-ratelimit-limit": "5000",
+          "x-ratelimit-reset": "1770000000",
+          "x-ratelimit-resource": "search",
+        },
+      },
+    );
+  };
+  const env = {
+    DASHBOARD_CACHE: kvStore(),
+    GITHUB_TOKEN: "shared-token",
+  };
+  try {
+    const first = await worker.fetch(
+      new Request("https://release.bar/api/_discover?period=week&lang=TypeScript"),
+      env,
+      { waitUntil: () => undefined },
+    );
+    assert.equal(first.status, 200);
+    const body = (await first.json()) as DashboardPayload;
+    assert.equal(body.title, "GitHub Hot");
+    assert.equal(body.projects[0]?.fullName, "acme/releasebar");
+    assert.equal(body.projects[0]?.version, "repo search");
+    assert.equal(body.projects[0]?.openIssues, 7);
+    assert.equal(body.cache?.quota?.remaining, 4999);
+    assert.match(body.cache?.message ?? "", /repository search/);
+
+    const second = await worker.fetch(
+      new Request("https://release.bar/api/_discover?period=week&lang=TypeScript"),
+      env,
+      { waitUntil: () => undefined },
+    );
+    assert.equal(second.status, 200);
+    assert.equal(calls, 1);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("worker falls back to stale discovery cache when GitHub search is rate limited", async () => {
+  const originalFetch = globalThis.fetch;
+  const cached = testDashboard("cached", [testProject({ owner: "cached", name: "repo" })]);
+  const env = {
+    DASHBOARD_CACHE: kvStore({
+      "discover:v2:week:all": JSON.stringify({
+        ...cached,
+        title: "GitHub Hot",
+        owners: [],
+        generatedAt: "2020-01-01T00:00:00Z",
+      }),
+    }),
+  };
+  globalThis.fetch = async () =>
+    Response.json({ message: "API rate limit exceeded" }, { status: 403 });
+  try {
+    const response = await worker.fetch(
+      new Request("https://release.bar/api/_discover?period=week"),
+      env,
+      { waitUntil: () => undefined },
+    );
+    assert.equal(response.status, 200);
+    const body = (await response.json()) as DashboardPayload;
+    assert.equal(body.cache?.state, "stale");
+    assert.equal(body.projects[0]?.fullName, "cached/repo");
+    assert.match(body.cache?.message ?? "", /cached search/);
+    assert.doesNotMatch(body.cache?.message ?? "", /install the app/i);
+
+    const coldResponse = await worker.fetch(
+      new Request("https://release.bar/api/_discover?period=month"),
+      { DASHBOARD_CACHE: kvStore() },
+      { waitUntil: () => undefined },
+    );
+    assert.equal(coldResponse.status, 429);
+    const coldBody = (await coldResponse.json()) as DashboardPayload;
+    assert.equal(coldBody.cache?.state, "error");
+    assert.match(coldBody.cache?.message ?? "", /repository search quota is exhausted/);
+    assert.doesNotMatch(coldBody.cache?.message ?? "", /install the app/i);
   } finally {
     globalThis.fetch = originalFetch;
   }

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -24,12 +24,21 @@
     type SortDirection,
     type SortKey,
   } from "./dashboard-view.js";
-  import { dashboardRoute, ownerDashboardPath, validRepoSlug } from "./routing.js";
+  import {
+    dashboardRoute,
+    ownerDashboardPath,
+    validRepoSlug,
+    type DiscoverPeriod,
+  } from "./routing.js";
   import type { ApiQuota, AuthPayload, DashboardPayload, Project } from "./types.js";
 
   const initialRoute = dashboardRoute(location.pathname, location.search);
   const storedDevMode = localStorage.getItem("releasedeck:dev-mode") === "true";
-  const initialView = parseViewState(location.search, initialRoute.isDefault, storedDevMode);
+  const initialView = parseViewState(
+    location.search,
+    initialRoute.discoverPeriod === "releasebar",
+    storedDevMode,
+  );
   const routeScope = initialRoute.owner ?? "default";
   const hiddenOwnersKey = `releasedeck:${routeScope}:hidden-owners`;
   const hiddenReposKey = `releasedeck:${routeScope}:hidden-repos`;
@@ -69,6 +78,14 @@
     minute: "2-digit",
   });
   const relativeFormat = new Intl.RelativeTimeFormat("en", { numeric: "auto" });
+  const discoverPeriods: Array<{ value: DiscoverPeriod; label: string }> = [
+    { value: "day", label: "today" },
+    { value: "week", label: "week" },
+    { value: "month", label: "month" },
+    { value: "year", label: "year" },
+    { value: "releasebar", label: "releasebar" },
+  ];
+  const discoverLanguages = ["TypeScript", "Python", "Rust", "Go", "Swift"];
 
   $: label = data ? ownerLabel(data) : initialRoute.label;
   $: subtitle = data?.subtitle ?? "Release debt across recently requested public dashboards.";
@@ -132,6 +149,8 @@
   );
   $: document.body.classList.toggle("dev-mode", devMode);
   $: document.title = `${label} · ReleaseBar`;
+  $: activeDiscoverPeriod = initialRoute.discoverPeriod ?? "week";
+  $: activeDiscoverLanguage = initialRoute.discoverLanguage;
   $: syncViewState(query, language, filter, sortKey, sortDirection, devMode);
 
   function ownerLabel(payload: DashboardPayload): string {
@@ -398,6 +417,25 @@
     localStorage.setItem("releasedeck:dev-mode", String(devMode));
   }
 
+  function discoverHref(period: DiscoverPeriod, nextLanguage = activeDiscoverLanguage): string {
+    const params = new URLSearchParams();
+    if (period !== "week") params.set("period", period);
+    if (nextLanguage.trim() && period !== "releasebar") params.set("hotLang", nextLanguage.trim());
+    const search = params.toString();
+    return search ? `/?${search}` : "/";
+  }
+
+  function discoverLanguageHref(nextLanguage: string): string {
+    return discoverHref(
+      activeDiscoverPeriod,
+      discoverLanguageActive(nextLanguage) ? "" : nextLanguage,
+    );
+  }
+
+  function discoverLanguageActive(nextLanguage: string): boolean {
+    return activeDiscoverLanguage.toLowerCase() === nextLanguage.toLowerCase();
+  }
+
   function syncViewState(
     activeQuery: string,
     activeLanguage: string,
@@ -417,7 +455,7 @@
         sortDirection: activeSortDirection,
         devMode: devEnabled,
       },
-      initialRoute.isDefault,
+      initialRoute.discoverPeriod === "releasebar",
     );
     if (nextSearch === location.search) return;
     const nextUrl = `${location.pathname}${nextSearch}${location.hash}`;
@@ -700,11 +738,19 @@
       ...typedCommands,
       {
         actionId: "dashboard:home",
-        title: "Open ReleaseBar Hot",
+        title: "Open GitHub Hot",
         subTitle: "root dashboard",
         group: "Dashboards",
-        keywords: ["home", "root", "hot"],
+        keywords: ["home", "root", "hot", "discover", "trending"],
         onRun: () => location.assign("/"),
+      },
+      {
+        actionId: "dashboard:releasebar",
+        title: "Open ReleaseBar Hot",
+        subTitle: "cached dashboards",
+        group: "Dashboards",
+        keywords: ["home", "root", "releasebar", "cache"],
+        onRun: () => location.assign(discoverHref("releasebar")),
       },
       ...ownerCommands,
       ...languages.map(languageCommand),
@@ -860,6 +906,42 @@
       {/if}
     </div>
   </header>
+
+  {#if initialRoute.isDefault}
+    <nav class="discover-nav" aria-label="Discover GitHub repositories">
+      <div class="discover-group" aria-label="Time range">
+        {#each discoverPeriods as period}
+          <a
+            class:active={activeDiscoverPeriod === period.value}
+            href={discoverHref(period.value)}
+            aria-current={activeDiscoverPeriod === period.value ? "page" : undefined}
+          >
+            {period.label}
+          </a>
+        {/each}
+      </div>
+      {#if activeDiscoverPeriod !== "releasebar"}
+        <div class="discover-group" aria-label="Language">
+          <a
+            class:active={!activeDiscoverLanguage}
+            href={discoverHref(activeDiscoverPeriod, "")}
+            aria-current={!activeDiscoverLanguage ? "page" : undefined}
+          >
+            all
+          </a>
+          {#each discoverLanguages as discoverLanguage}
+            <a
+              class:active={discoverLanguageActive(discoverLanguage)}
+              href={discoverLanguageHref(discoverLanguage)}
+              aria-current={discoverLanguageActive(discoverLanguage) ? "page" : undefined}
+            >
+              {discoverLanguage}
+            </a>
+          {/each}
+        </div>
+      {/if}
+    </nav>
+  {/if}
 
   {#if settingsOpen}
     <div class="settings-panel" aria-label="Dashboard settings" data-open>

--- a/src/routing.ts
+++ b/src/routing.ts
@@ -6,7 +6,11 @@ export type DashboardRoute = {
   isDefault: boolean;
   extraOwners: string[];
   repos: string[];
+  discoverPeriod: DiscoverPeriod | null;
+  discoverLanguage: string;
 };
+
+export type DiscoverPeriod = "day" | "week" | "month" | "year" | "releasebar";
 
 export type RouteOptions = {
   includeForks: boolean;
@@ -18,6 +22,14 @@ export const workerApiOrigin = "";
 export const workersDevApiOrigin = "https://releasedeck-api.steipete.workers.dev";
 const ownerListKey = "owners";
 const repoListKey = "repos";
+const discoverLanguageKey = "hotLang";
+const discoverPeriodValues = new Set<DiscoverPeriod>([
+  "day",
+  "week",
+  "month",
+  "year",
+  "releasebar",
+]);
 
 export function ownerFromPath(pathname: string): string | null {
   const [first] = pathname.split("/").filter(Boolean);
@@ -60,6 +72,17 @@ export function ownerDashboardPath(owner: string): string {
   return `/${encodeURIComponent(owner.trim().replace(/^@/, "").toLowerCase())}`;
 }
 
+export function discoverPeriodFromSearch(search: string): DiscoverPeriod {
+  const value = (new URLSearchParams(search).get("period") ?? "week").toLowerCase();
+  if (value === "today") return "day";
+  return discoverPeriodValues.has(value as DiscoverPeriod) ? (value as DiscoverPeriod) : "week";
+}
+
+export function discoverLanguageFromSearch(search: string): string {
+  const value = (new URLSearchParams(search).get(discoverLanguageKey) ?? "").trim();
+  return /^[a-z0-9+#.\-\s]{1,32}$/i.test(value) ? value : "";
+}
+
 export function dashboardRoute(
   pathname: string,
   search = "",
@@ -83,15 +106,27 @@ export function dashboardRoute(
 
   if (!owner) {
     const custom = extraOwners.length > 0 || repos.length > 0;
-    const apiPath = custom ? `/api/dashboard${suffix}` : `/api/_hot${suffix}`;
+    const discoverPeriod = discoverPeriodFromSearch(search);
+    const discoverLanguage = discoverLanguageFromSearch(search);
+    const discoverQuery = new URLSearchParams();
+    if (discoverPeriod !== "week") discoverQuery.set("period", discoverPeriod);
+    if (discoverLanguage) discoverQuery.set("lang", discoverLanguage);
+    const discoverSuffix = discoverQuery.size > 0 ? `?${discoverQuery}` : "";
+    const apiPath = custom
+      ? `/api/dashboard${suffix}`
+      : discoverPeriod === "releasebar"
+        ? "/api/_hot"
+        : `/api/_discover${discoverSuffix}`;
     return {
       owner: null,
       apiPath: `${apiOrigin}${apiPath}`,
       fallbackApiPath: apiOrigin === "" ? `${workersDevApiOrigin}${apiPath}` : null,
-      label: custom ? "custom deck" : "ReleaseBar Hot",
+      label: custom ? "custom deck" : "GitHub Hot",
       isDefault: !custom,
       extraOwners,
       repos,
+      discoverPeriod: custom ? null : discoverPeriod,
+      discoverLanguage: custom ? "" : discoverLanguage,
     };
   }
 
@@ -107,5 +142,7 @@ export function dashboardRoute(
     isDefault: false,
     extraOwners,
     repos,
+    discoverPeriod: null,
+    discoverLanguage: "",
   };
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -169,6 +169,43 @@ h1 {
   box-shadow: 0 0 18px var(--green);
 }
 
+.discover-nav {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px 18px;
+  margin: -8px 0 22px;
+}
+
+.discover-group {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.discover-group a {
+  display: inline-flex;
+  min-height: 32px;
+  align-items: center;
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  padding: 0 11px;
+  background: rgba(16, 19, 15, 0.82);
+  color: var(--muted);
+  font-size: 13px;
+}
+
+.discover-group a:hover,
+.discover-group a:focus-visible,
+.discover-group a.active {
+  border-color: var(--green);
+  color: var(--text);
+  outline: 0;
+}
+
+.discover-group a.active {
+  background: rgba(156, 255, 87, 0.075);
+}
+
 /* Console */
 
 .console {

--- a/worker/index.ts
+++ b/worker/index.ts
@@ -14,12 +14,14 @@ import {
   gitHubInstallationTokenSchema,
   gitHubOAuthTokenSchema,
   gitHubOAuthUserSchema,
+  gitHubSearchRepositoryListSchema,
   hotIndexSchema,
   parseGitHubResponse,
   safeJsonParse,
   storedAuthSessionSchema,
   tryJsonParse,
   type GitHubInstallationRepository,
+  type GitHubSearchRepository,
 } from "./schemas.js";
 import type {
   ApiQuota,
@@ -92,6 +94,8 @@ const hotOwnerLimit = 3;
 const hotSourceLimit = 24;
 const hotIndexLimit = 100;
 const hotCacheTtlMs = 5 * 60 * 1000;
+const discoverLimit = 40;
+const discoverCacheTtlMs = 60 * 60 * 1000;
 const maxCustomSources = 8;
 const schemaVersion = 2;
 const dashboardCachePrefix = `dashboard:v${schemaVersion}:`;
@@ -1444,6 +1448,248 @@ async function hotResponse(env: Env): Promise<Response> {
   return jsonResponse(payload);
 }
 
+type DiscoverPeriod = "day" | "week" | "month" | "year";
+
+const discoverPeriods = new Set<DiscoverPeriod>(["day", "week", "month", "year"]);
+
+function discoverPeriod(url: URL): DiscoverPeriod {
+  const raw = (url.searchParams.get("period") ?? "week").toLowerCase();
+  if (raw === "today") return "day";
+  return discoverPeriods.has(raw as DiscoverPeriod) ? (raw as DiscoverPeriod) : "week";
+}
+
+function discoverLanguage(url: URL): string {
+  const raw = (url.searchParams.get("lang") ?? "").trim();
+  return /^[a-z0-9+#.\-\s]{1,32}$/i.test(raw) ? raw : "";
+}
+
+function discoverCacheKey(period: DiscoverPeriod, language: string): string {
+  return `discover:v${schemaVersion}:${period}:${language.trim().toLowerCase() || "all"}`;
+}
+
+function discoverSince(period: DiscoverPeriod): string {
+  const days = period === "day" ? 1 : period === "week" ? 7 : period === "month" ? 30 : 365;
+  const date = new Date(Date.now() - days * 86400000);
+  return date.toISOString().slice(0, 10);
+}
+
+function discoverPeriodLabel(period: DiscoverPeriod): string {
+  return period === "day" ? "today" : `this ${period}`;
+}
+
+function discoverSearchQuery(period: DiscoverPeriod, language: string): string {
+  const minimumStars =
+    period === "day" ? 50 : period === "week" ? 100 : period === "month" ? 250 : 1000;
+  const parts = [
+    `stars:>${minimumStars}`,
+    `pushed:>=${discoverSince(period)}`,
+    "archived:false",
+    "fork:false",
+  ];
+  if (language) {
+    parts.push(`language:"${language.replaceAll('"', "")}"`);
+  }
+  return parts.join(" ");
+}
+
+function quotaFromResponse(response: Response, env: Env): ApiQuota {
+  const remaining = parseHeaderInt(response.headers.get("x-ratelimit-remaining"));
+  const limit = parseHeaderInt(response.headers.get("x-ratelimit-limit"));
+  const reset = parseHeaderInt(response.headers.get("x-ratelimit-reset"));
+  return {
+    source: env.GITHUB_TOKEN ? "shared" : "anonymous",
+    account: null,
+    remaining,
+    limit,
+    resetAt: reset === null ? null : new Date(reset * 1000).toISOString(),
+    resource: response.headers.get("x-ratelimit-resource"),
+  };
+}
+
+function parseHeaderInt(value: string | null): number | null {
+  if (!value) return null;
+  const parsed = Number.parseInt(value, 10);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function discoverFreshness(repo: GitHubSearchRepository): Project["freshness"] {
+  const stars = repo.stargazers_count ?? 0;
+  const pushedAt = repo.pushed_at ? Date.parse(repo.pushed_at) : 0;
+  const ageDays = pushedAt ? Math.max(0, (Date.now() - pushedAt) / 86400000) : 365;
+  if (stars >= 1000 && ageDays <= 7) return "hot";
+  if (stars >= 250 && ageDays <= 30) return "busy";
+  return "warm";
+}
+
+function discoverProject(repo: GitHubSearchRepository): Project {
+  const owner = repo.owner.login;
+  const fullName = repo.full_name;
+  const defaultBranch = repo.default_branch || "main";
+  const releaseUrl = `${repo.html_url}/releases`;
+  return {
+    owner,
+    name: repo.name,
+    fullName,
+    description: repo.description,
+    url: repo.html_url,
+    defaultBranch,
+    language: repo.language,
+    stars: repo.stargazers_count ?? 0,
+    forks: repo.forks_count ?? 0,
+    openIssues: repo.open_issues_count ?? 0,
+    openPullRequests: 0,
+    issuesUrl: `${repo.html_url}/issues`,
+    pullRequestsUrl: `${repo.html_url}/pulls`,
+    archived: repo.archived ?? false,
+    pushedAt: repo.pushed_at,
+    updatedAt: repo.updated_at,
+    latestCommitSha: defaultBranch,
+    latestCommitDate: repo.pushed_at,
+    version: "repo search",
+    releaseName: null,
+    releaseUrl,
+    releaseDate: null,
+    commitsSinceRelease: null,
+    compareUrl: null,
+    ciState: "unknown",
+    ciStatus: null,
+    ciConclusion: null,
+    ciWorkflow: null,
+    ciUrl: null,
+    ciRunDate: null,
+    freshness: discoverFreshness(repo),
+  };
+}
+
+function discoverErrorPayload(
+  period: DiscoverPeriod,
+  language: string,
+  env: Env,
+  error: unknown,
+): DashboardPayload {
+  const generatedAt = new Date().toISOString();
+  return {
+    title: "GitHub Hot",
+    subtitle: `GitHub repository search for ${language ? `${language} projects ` : "projects "}${discoverPeriodLabel(period)}.`,
+    canonicalDomain: env.RELEASEDECK_CANONICAL_DOMAIN ?? "release.bar",
+    generatedAt,
+    owners: [],
+    options: {
+      includeForks: false,
+      includeArchived: false,
+      includeUnreleased: true,
+      repoLimit: discoverLimit,
+    },
+    cache: {
+      state: "error",
+      stale: true,
+      capped: false,
+      repoLimit: discoverLimit,
+      generatedAt,
+      message: discoveryErrorMessage(error),
+    },
+    totals: dashboardTotals([]),
+    projects: [],
+  };
+}
+
+function discoveryErrorMessage(error: unknown): string {
+  if (isGitHubRateLimit(error)) {
+    return "GitHub repository search quota is exhausted. Try again after the search quota resets.";
+  }
+  return dashboardErrorMessage(error);
+}
+
+async function discoverPayload(
+  period: DiscoverPeriod,
+  language: string,
+  env: Env,
+): Promise<DashboardPayload> {
+  const search = new URL("https://api.github.com/search/repositories");
+  search.searchParams.set("q", discoverSearchQuery(period, language));
+  search.searchParams.set("sort", "stars");
+  search.searchParams.set("order", "desc");
+  search.searchParams.set("per_page", String(discoverLimit));
+
+  const response = await workerFetch(search.toString(), {
+    headers: {
+      accept: "application/vnd.github+json",
+      ...(env.GITHUB_TOKEN ? { authorization: `Bearer ${env.GITHUB_TOKEN}` } : {}),
+      "user-agent": "ReleaseBar",
+      "x-github-api-version": "2022-11-28",
+    },
+  });
+  const body = parseGitHubResponse(
+    gitHubSearchRepositoryListSchema,
+    await response.json(),
+    "repository search",
+  );
+  if (!response.ok) {
+    const message = body.message ?? `GitHub repository search failed: ${response.status}`;
+    if (response.status === 403 || /rate limit|secondary rate/i.test(message)) {
+      throw new GitHubRateLimitError(message, parseHeaderInt(response.headers.get("retry-after")));
+    }
+    throw new Error(message);
+  }
+
+  const projects = (body.items ?? [])
+    .filter((repo) => !repo.private && !repo.fork && !repo.archived)
+    .map(discoverProject);
+  const generatedAt = new Date().toISOString();
+  const total = body.total_count ?? projects.length;
+  return {
+    title: "GitHub Hot",
+    subtitle: `Popular public GitHub repositories active ${discoverPeriodLabel(period)}${
+      language ? ` in ${language}` : ""
+    }.`,
+    canonicalDomain: env.RELEASEDECK_CANONICAL_DOMAIN ?? "release.bar",
+    generatedAt,
+    owners: [],
+    options: {
+      includeForks: false,
+      includeArchived: false,
+      includeUnreleased: true,
+      repoLimit: discoverLimit,
+    },
+    cache: {
+      state: "fresh",
+      stale: false,
+      capped: total > projects.length,
+      repoLimit: discoverLimit,
+      generatedAt,
+      quota: quotaFromResponse(response, env),
+      message: "approximated with GitHub repository search; star velocity needs GH Archive",
+    },
+    totals: dashboardTotals(projects),
+    projects,
+  };
+}
+
+async function discoverResponse(env: Env, url: URL): Promise<Response> {
+  const period = discoverPeriod(url);
+  const language = discoverLanguage(url);
+  const key = discoverCacheKey(period, language);
+  const cached = await readCached(env, key);
+  const ageMs = cached ? Date.now() - Date.parse(cached.generatedAt) : Number.POSITIVE_INFINITY;
+  if (cached && ageMs < discoverCacheTtlMs) {
+    return jsonResponse(withCacheState(cached, "fresh"));
+  }
+
+  try {
+    const payload = await discoverPayload(period, language, env);
+    await writeCached(env, key, payload);
+    return jsonResponse(payload);
+  } catch (error) {
+    if (cached) {
+      return jsonResponse(
+        withCacheState(cached, "stale", `${discoveryErrorMessage(error)} Showing cached search.`),
+      );
+    }
+    const payload = discoverErrorPayload(period, language, env, error);
+    return jsonResponse(payload, errorStatus(error), retryAfterHeaders(error));
+  }
+}
+
 async function acquireBuildLock(env: Env, key: string): Promise<BuildLock | null> {
   if (!env.DASHBOARD_LOCKS) {
     return {
@@ -1987,6 +2233,9 @@ async function routeRequest(
   }
   if (url.pathname === "/api/_hot") {
     return hotResponse(env);
+  }
+  if (url.pathname === "/api/_discover") {
+    return discoverResponse(env, url);
   }
   if (url.pathname.startsWith("/api/")) {
     return ownerResponse(request, env, context);

--- a/worker/schemas.ts
+++ b/worker/schemas.ts
@@ -50,6 +50,33 @@ export const gitHubInstallationTokenSchema = v.looseObject({
   message: v.optional(v.string()),
 });
 
+export const gitHubSearchRepositorySchema = v.looseObject({
+  name: v.string(),
+  full_name: v.string(),
+  private: v.optional(v.boolean()),
+  fork: v.optional(v.boolean()),
+  archived: v.optional(v.boolean()),
+  html_url: v.string(),
+  description: v.nullable(v.string()),
+  default_branch: v.optional(v.string()),
+  language: v.nullable(v.string()),
+  stargazers_count: v.optional(v.number()),
+  forks_count: v.optional(v.number()),
+  open_issues_count: v.optional(v.number()),
+  pushed_at: v.nullable(v.string()),
+  updated_at: v.nullable(v.string()),
+  owner: v.looseObject({
+    login: v.string(),
+  }),
+});
+
+export const gitHubSearchRepositoryListSchema = v.looseObject({
+  total_count: v.optional(v.number()),
+  incomplete_results: v.optional(v.boolean()),
+  items: v.optional(v.array(gitHubSearchRepositorySchema)),
+  message: v.optional(v.string()),
+});
+
 const authUserSchema = v.object({
   id: v.number(),
   login: v.string(),
@@ -72,6 +99,7 @@ export type GitHubOAuthUser = v.InferOutput<typeof gitHubOAuthUserSchema>;
 export type GitHubInstallation = v.InferOutput<typeof gitHubInstallationSchema>;
 export type GitHubInstallationRepository = v.InferOutput<typeof gitHubInstallationRepositorySchema>;
 export type GitHubInstallationToken = v.InferOutput<typeof gitHubInstallationTokenSchema>;
+export type GitHubSearchRepository = v.InferOutput<typeof gitHubSearchRepositorySchema>;
 
 export function parseGitHubResponse<TSchema extends v.GenericSchema>(
   schema: TSchema,


### PR DESCRIPTION
## Summary
- add cached GitHub repository-search discovery for the root GitHub Hot dashboard
- add today, week, month, year, and ReleaseBar sections plus language filters
- preserve client language filtering separately from server discovery language with hotLang

## Verification
- npm run format
- npm run check:static
- codex-review --parallel-tests "npm run check:static"
