### PR TITLE
fix: cap large owner dashboard scans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Added a GitHub Hot root dashboard backed by cached GitHub repository search, with today/week/month/year and language filters.
+- Capped API owner scans at the newest 200 public repositories so huge organizations build promptly instead of staying queued.
 - Made project owners link to their ReleaseBar dashboards while repository names still open GitHub.
 - Show cached partial source data while cold combined dashboards rebuild in the background.
 - Added owner-only public dashboard defaults so saved sources and visibility apply at clean owner URLs.

--- a/scripts/lib/dashboard.test.ts
+++ b/scripts/lib/dashboard.test.ts
@@ -2487,6 +2487,103 @@ test("dashboard repo cap applies after release eligibility", async () => {
   assert.equal(payload.cache?.capped, true);
 });
 
+test("dashboard repo scan cap stops giant owners after recent repos", async () => {
+  const repo = (name: string) => ({
+    owner: { login: "owner" },
+    name,
+    full_name: `owner/${name}`,
+    description: null,
+    html_url: `https://github.com/owner/${name}`,
+    default_branch: "main",
+    language: null,
+    stargazers_count: 0,
+    forks_count: 0,
+    open_issues_count: 0,
+    archived: false,
+    pushed_at: null,
+    updated_at: null,
+    fork: false,
+    private: false,
+  });
+  const releaseFetches: string[] = [];
+
+  const payload = await buildDashboard({
+    title: "ReleaseBar",
+    subtitle: "test",
+    canonicalDomain: "example.com",
+    owners: [{ type: "user", login: "owner" }],
+    includeForks: false,
+    includeArchived: false,
+    repoLimit: 2,
+    repoScanLimit: 2,
+    fetch: async (url) => {
+      const path = new URL(String(url)).pathname;
+      if (path === "/users/owner/repos") {
+        return Response.json([repo("empty-a"), repo("empty-b"), repo("released")]);
+      }
+      if (path.endsWith("/releases")) {
+        releaseFetches.push(path.split("/")[3] ?? "");
+        return Response.json([]);
+      }
+      throw new Error(`unexpected ${path}`);
+    },
+  });
+
+  assert.deepEqual(releaseFetches, ["empty-a", "empty-b"]);
+  assert.equal(payload.totals.repos, 0);
+  assert.equal(payload.cache?.capped, true);
+  assert.match(payload.cache?.message ?? "", /scanned 2 recently pushed repos/);
+});
+
+test("dashboard repo scan cap marks full page boundary truncation as capped", async () => {
+  const repo = (name: string) => ({
+    owner: { login: "owner" },
+    name,
+    full_name: `owner/${name}`,
+    description: null,
+    html_url: `https://github.com/owner/${name}`,
+    default_branch: "main",
+    language: null,
+    stargazers_count: 0,
+    forks_count: 0,
+    open_issues_count: 0,
+    archived: false,
+    pushed_at: null,
+    updated_at: null,
+    fork: false,
+    private: false,
+  });
+  const pages: string[] = [];
+
+  const payload = await buildDashboard({
+    title: "ReleaseBar",
+    subtitle: "test",
+    canonicalDomain: "example.com",
+    owners: [{ type: "user", login: "owner" }],
+    includeForks: false,
+    includeArchived: false,
+    repoLimit: 200,
+    repoScanLimit: 100,
+    fetch: async (url) => {
+      const parsed = new URL(String(url));
+      const path = parsed.pathname;
+      if (path === "/users/owner/repos") {
+        pages.push(parsed.searchParams.get("page") ?? "");
+        return Response.json(Array.from({ length: 100 }, (_, index) => repo(`empty-${index}`)));
+      }
+      if (path.endsWith("/releases")) {
+        return Response.json([]);
+      }
+      throw new Error(`unexpected ${path}`);
+    },
+  });
+
+  assert.deepEqual(pages, ["1"]);
+  assert.equal(payload.totals.repos, 0);
+  assert.equal(payload.cache?.capped, true);
+  assert.match(payload.cache?.message ?? "", /scanned 100 recently pushed repos/);
+});
+
 test("dashboard repo cap keeps paginating until eligible repos survive filters", async () => {
   const repo = (name: string, overrides = {}) => ({
     owner: { login: "owner" },

--- a/scripts/lib/dashboard.ts
+++ b/scripts/lib/dashboard.ts
@@ -19,6 +19,7 @@ export type DashboardBuildOptions = {
   excludeRepos?: string[];
   includeRepos?: string[];
   repoLimit?: number;
+  repoScanLimit?: number;
   token?: string;
   quotaSource?: ApiQuota["source"];
   quotaAccount?: string | null;
@@ -853,13 +854,20 @@ export async function buildDashboard(options: DashboardBuildOptions): Promise<Da
   if (options.repoLimit) {
     for (const owner of options.owners) {
       const ownerStart = projects.length;
+      let scanned = 0;
       let page = 1;
-      while (projects.length - ownerStart <= options.repoLimit) {
+      const scanLimit = options.repoScanLimit ?? Number.POSITIVE_INFINITY;
+      while (projects.length - ownerStart <= options.repoLimit && scanned < scanLimit) {
         const repos = await ownerRepos(client, owner, page);
         if (repos.length === 0) {
           break;
         }
         for (const repo of repos) {
+          if (scanned >= scanLimit) {
+            capped = true;
+            break;
+          }
+          scanned += 1;
           const ownerCount = projects.length - ownerStart;
           await addRepo(repo, `${owner.login} ${ownerCount + 1}/${options.repoLimit}`);
           if (projects.length - ownerStart > options.repoLimit) {
@@ -868,6 +876,10 @@ export async function buildDashboard(options: DashboardBuildOptions): Promise<Da
           }
         }
         if (repos.length < 100) {
+          break;
+        }
+        if (scanned >= scanLimit) {
+          capped = true;
           break;
         }
         page += 1;
@@ -927,6 +939,11 @@ export async function buildDashboard(options: DashboardBuildOptions): Promise<Da
       repoLimit: options.repoLimit ?? null,
       generatedAt,
       quota: client.quota,
+      ...(capped && options.repoScanLimit
+        ? {
+            message: `scanned ${options.repoScanLimit} recently pushed repos per owner`,
+          }
+        : {}),
     },
     totals: {
       repos: projects.length,

--- a/worker/index.ts
+++ b/worker/index.ts
@@ -89,6 +89,7 @@ const coldBuildWaitMs = 15 * 1000;
 const buildLockTtlMs = 2 * 60 * 1000;
 const buildLockRefreshMs = 30 * 1000;
 const repoLimit = 200;
+const repoScanLimit = 200;
 const hotLimit = 50;
 const hotOwnerLimit = 3;
 const hotSourceLimit = 24;
@@ -1756,6 +1757,7 @@ async function rebuild(dashboard: DashboardRequest, env: Env): Promise<Dashboard
       excludeRepos: dashboard.profile?.hiddenRepos,
       ...optionsFromUrl(dashboard.url),
       repoLimit,
+      repoScanLimit,
       token: dashboard.token ?? env.GITHUB_TOKEN,
       quotaSource:
         dashboard.quotaSource ?? (dashboard.token || env.GITHUB_TOKEN ? "shared" : "anonymous"),


### PR DESCRIPTION
## Summary
- cap Worker owner dashboard scans at the newest 200 public repos per owner
- keep the existing 200 displayed-repo cap and mark scan-truncated dashboards as capped
- add regressions for giant-owner scan truncation and page-boundary capped state

## Verification
- npm run format
- npm run check:static
- codex-review --parallel-tests "npm run check:static"
