### PR TITLE
fix: keep large owner builds within worker limits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 - Added a GitHub Hot root dashboard backed by cached GitHub repository search, with today/week/month/year and language filters.
-- Capped API owner scans at the newest 50 public repositories so huge organizations build promptly instead of staying queued.
+- Capped API owner scans at the newest 12 public repositories so huge organizations build promptly instead of staying queued.
 - Made project owners link to their ReleaseBar dashboards while repository names still open GitHub.
 - Show cached partial source data while cold combined dashboards rebuild in the background.
 - Added owner-only public dashboard defaults so saved sources and visibility apply at clean owner URLs.
@@ -19,7 +19,7 @@
 - Added a `need attention` dashboard filter for hot and busy repositories, with the metric tile acting as a shortcut.
 - Migrated the app shell to Svelte/Vite with keyboard-accessible account dropdowns, a Cmd-K command palette, and tighter ReleaseBar-themed controls.
 - Hardened GitHub auth, cache, and rate-limit handling with validated API payloads, cached installation tokens, scoped visibility settings, and PR commit linting.
-- Raised owner dashboard builds from 8 to 50 recent public repositories and made capped dashboards show the cap size.
+- Raised owner dashboard builds from 8 to 12 recent public repositories and made capped dashboards show the cap size.
 - Filtered GitHub App selected repositories to public repos before auth state, coverage checks, or dashboards can use them.
 - Fixed GitHub App install redirects to use the real `releasebar-app` app slug while keeping `release.bar` OAuth callbacks.
 - Changed the root dashboard to `ReleaseBar Hot`, built from cached public dashboards instead of the maintainer snapshot.

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Set `GITHUB_TOKEN` for higher API limits. GitHub Actions uses the built-in token
 - GitHub App installation gives ReleaseBar dedicated GitHub API quota for the selected account/repositories; public dashboards still fall back to the shared server token and cache
 - private repositories are ignored even when selected in GitHub App installation; ReleaseBar only stores and renders public repository metadata
 
-The Worker in `worker/index.ts` serves both the static app shell and the generic owner API. It validates public GitHub owners, builds a capped public dashboard from the 50 most recently pushed public repositories per owner, stores dashboards and repo fragments in KV, serves fresh cache for 1h, serves stale cache while revalidating, and builds the root hot board from existing cached dashboards. A Durable Object binding prevents repeated cold requests from stampeding GitHub. Configure `DASHBOARD_CACHE`, `DASHBOARD_LOCKS`, and `GITHUB_TOKEN` before deploying the Worker.
+The Worker in `worker/index.ts` serves both the static app shell and the generic owner API. It validates public GitHub owners, builds a capped public dashboard from the 12 most recently pushed public repositories per owner, stores dashboards and repo fragments in KV, serves fresh cache for 1h, serves stale cache while revalidating, and builds the root hot board from existing cached dashboards. A Durable Object binding prevents repeated cold requests from stampeding GitHub. Configure `DASHBOARD_CACHE`, `DASHBOARD_LOCKS`, and `GITHUB_TOKEN` before deploying the Worker.
 
 ### GitHub App Login
 

--- a/scripts/lib/dashboard.test.ts
+++ b/scripts/lib/dashboard.test.ts
@@ -280,9 +280,9 @@ test("dashboard project sorting handles dev issue and pull request counts numeri
 });
 
 test("worker builds root hot dashboard from cached dashboards", async () => {
-  const alphaKey = dashboardCacheKey({ owner: "alpha", schemaVersion: 3 });
-  const betaKey = dashboardCacheKey({ owner: "beta", schemaVersion: 3 });
-  const forksKey = dashboardCacheKey({ owner: "forks", includeForks: true, schemaVersion: 3 });
+  const alphaKey = dashboardCacheKey({ owner: "alpha", schemaVersion: 4 });
+  const betaKey = dashboardCacheKey({ owner: "beta", schemaVersion: 4 });
+  const forksKey = dashboardCacheKey({ owner: "forks", includeForks: true, schemaVersion: 4 });
   const env = {
     DASHBOARD_CACHE: kvStore({
       "hot:index:v3": JSON.stringify([alphaKey]),
@@ -337,7 +337,7 @@ test("worker builds root hot dashboard from cached dashboards", async () => {
           repoLimit: 200,
         },
       }),
-      [dashboardCacheKey({ owner: "gamma", schemaVersion: 3 })]: JSON.stringify(
+      [dashboardCacheKey({ owner: "gamma", schemaVersion: 4 })]: JSON.stringify(
         testDashboard("gamma", [
           testProject({
             owner: "gamma",
@@ -623,7 +623,7 @@ test("dashboard build records GitHub quota headers", async () => {
 });
 
 test("worker preserves cached quota metadata on fresh responses", async () => {
-  const key = dashboardCacheKey({ owner: "owner", schemaVersion: 3 });
+  const key = dashboardCacheKey({ owner: "owner", schemaVersion: 4 });
   const dashboard = testDashboard("owner", []);
   dashboard.generatedAt = new Date().toISOString();
   if (dashboard.cache) {
@@ -712,8 +712,8 @@ test("worker serves partial cached sources while combined dashboard rebuilds", a
       fetch: async () => new Response(null, { status: 409 }),
     }),
   };
-  const alphaKey = dashboardCacheKey({ owner: "alpha", schemaVersion: 3 });
-  const betaKey = dashboardCacheKey({ owner: "beta", schemaVersion: 3 });
+  const alphaKey = dashboardCacheKey({ owner: "alpha", schemaVersion: 4 });
+  const betaKey = dashboardCacheKey({ owner: "beta", schemaVersion: 4 });
 
   try {
     const response = await worker.fetch(

--- a/worker/index.ts
+++ b/worker/index.ts
@@ -88,8 +88,8 @@ const installationTokenTtlSeconds = 50 * 60;
 const coldBuildWaitMs = 15 * 1000;
 const buildLockTtlMs = 2 * 60 * 1000;
 const buildLockRefreshMs = 30 * 1000;
-const repoLimit = 50;
-const repoScanLimit = 50;
+const repoLimit = 12;
+const repoScanLimit = 12;
 const hotLimit = 50;
 const hotOwnerLimit = 3;
 const hotSourceLimit = 24;
@@ -98,10 +98,14 @@ const hotCacheTtlMs = 5 * 60 * 1000;
 const discoverLimit = 40;
 const discoverCacheTtlMs = 60 * 60 * 1000;
 const maxCustomSources = 8;
-const schemaVersion = 3;
-const dashboardCachePrefix = `dashboard:v${schemaVersion}:`;
-const hotCacheKey = `hot:v${schemaVersion}`;
-const hotIndexKey = `hot:index:v${schemaVersion}`;
+const dashboardSchemaVersion = 4;
+const previousDashboardSchemaVersion = 3;
+const auxiliaryCacheSchemaVersion = 3;
+const dashboardCachePrefix = `dashboard:v${dashboardSchemaVersion}:`;
+const previousDashboardCachePrefix = `dashboard:v${previousDashboardSchemaVersion}:`;
+const dashboardCachePrefixes = [dashboardCachePrefix, previousDashboardCachePrefix];
+const hotCacheKey = `hot:v${auxiliaryCacheSchemaVersion}`;
+const hotIndexKey = `hot:index:v${auxiliaryCacheSchemaVersion}`;
 const sessionCookie = "rd_session";
 const installReturnCookie = "rd_install_return";
 const sessionMaxAgeSeconds = 30 * 24 * 60 * 60;
@@ -1271,7 +1275,7 @@ async function partialDashboardPayload(
       dashboardCacheKey({
         owner,
         ...options,
-        schemaVersion,
+        schemaVersion: dashboardSchemaVersion,
       }),
     ),
     ...dashboard.includeRepos.map((repo) =>
@@ -1279,7 +1283,7 @@ async function partialDashboardPayload(
         owner: "custom",
         repos: [repo],
         ...options,
-        schemaVersion,
+        schemaVersion: dashboardSchemaVersion,
       }),
     ),
   ];
@@ -1336,11 +1340,14 @@ async function readCachedDashboards(env: Env): Promise<DashboardPayload[]> {
   const dashboards: DashboardPayload[] = [];
   let keys = await readHotIndex(env);
   if (keys.length < hotSourceLimit && env.DASHBOARD_CACHE.list) {
-    const page = await env.DASHBOARD_CACHE.list({
-      prefix: dashboardCachePrefix,
-      limit: hotSourceLimit,
-    });
-    keys = [...new Set([...keys, ...page.keys.map((key) => key.name)])];
+    for (const prefix of dashboardCachePrefixes) {
+      if (keys.length >= hotSourceLimit) break;
+      const page = await env.DASHBOARD_CACHE.list({
+        prefix,
+        limit: hotSourceLimit,
+      });
+      keys = [...new Set([...keys, ...page.keys.map((key) => key.name)])];
+    }
   }
 
   for (const key of keys.slice(0, hotSourceLimit)) {
@@ -1365,7 +1372,9 @@ async function readHotIndex(env: Env): Promise<string[]> {
   const raw = await env.DASHBOARD_CACHE?.get(hotIndexKey);
   if (!raw) return [];
   const keys = safeJsonParse(hotIndexSchema, raw, "hot index");
-  return keys ? keys.filter((key) => key.startsWith(dashboardCachePrefix)) : [];
+  return keys
+    ? keys.filter((key) => dashboardCachePrefixes.some((prefix) => key.startsWith(prefix)))
+    : [];
 }
 
 async function rememberHotDashboard(
@@ -1465,7 +1474,7 @@ function discoverLanguage(url: URL): string {
 }
 
 function discoverCacheKey(period: DiscoverPeriod, language: string): string {
-  return `discover:v${schemaVersion}:${period}:${language.trim().toLowerCase() || "all"}`;
+  return `discover:v${auxiliaryCacheSchemaVersion}:${period}:${language.trim().toLowerCase() || "all"}`;
 }
 
 function discoverSince(period: DiscoverPeriod): string {
@@ -2007,7 +2016,7 @@ async function ownerResponse(
     repos: includeRepos,
     salt: profile?.updatedAt,
     ...options,
-    schemaVersion,
+    schemaVersion: dashboardSchemaVersion,
   });
   const cached = await readCached(env, key);
   const ageMs = cached ? Date.now() - Date.parse(cached.generatedAt) : Number.POSITIVE_INFINITY;


### PR DESCRIPTION
## Summary
- lower production owner dashboard scans to 12 recently pushed public repos so huge orgs fit Worker limits
- bump owner dashboard cache keys to v4 while keeping hot/discovery caches on v3
- let the hot board read both v4 and existing v3 cached dashboard entries

## Proof
- npm run check:static
- codex-review --parallel-tests "npm run check:static"
