### PR TITLE
feat: progressively cache dashboard builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 - Added a GitHub Hot root dashboard backed by cached GitHub repository search, with today/week/month/year and language filters.
-- Capped API owner scans at the newest 12 public repositories so huge organizations build promptly instead of staying queued.
+- Progressively cache API owner scans in 12-repository batches so huge organizations show rows while the dashboard keeps updating.
 - Made project owners link to their ReleaseBar dashboards while repository names still open GitHub.
 - Show cached partial source data while cold combined dashboards rebuild in the background.
 - Added owner-only public dashboard defaults so saved sources and visibility apply at clean owner URLs.
@@ -19,7 +19,7 @@
 - Added a `need attention` dashboard filter for hot and busy repositories, with the metric tile acting as a shortcut.
 - Migrated the app shell to Svelte/Vite with keyboard-accessible account dropdowns, a Cmd-K command palette, and tighter ReleaseBar-themed controls.
 - Hardened GitHub auth, cache, and rate-limit handling with validated API payloads, cached installation tokens, scoped visibility settings, and PR commit linting.
-- Raised owner dashboard builds from 8 to 12 recent public repositories and made capped dashboards show the cap size.
+- Raised owner dashboard builds from 8 to 200 recent public repositories with progressive 12-repository batches and visible progress.
 - Filtered GitHub App selected repositories to public repos before auth state, coverage checks, or dashboards can use them.
 - Fixed GitHub App install redirects to use the real `releasebar-app` app slug while keeping `release.bar` OAuth callbacks.
 - Changed the root dashboard to `ReleaseBar Hot`, built from cached public dashboards instead of the maintainer snapshot.

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Set `GITHUB_TOKEN` for higher API limits. GitHub Actions uses the built-in token
 - GitHub App installation gives ReleaseBar dedicated GitHub API quota for the selected account/repositories; public dashboards still fall back to the shared server token and cache
 - private repositories are ignored even when selected in GitHub App installation; ReleaseBar only stores and renders public repository metadata
 
-The Worker in `worker/index.ts` serves both the static app shell and the generic owner API. It validates public GitHub owners, builds a capped public dashboard from the 12 most recently pushed public repositories per owner, stores dashboards and repo fragments in KV, serves fresh cache for 1h, serves stale cache while revalidating, and builds the root hot board from existing cached dashboards. A Durable Object binding prevents repeated cold requests from stampeding GitHub. Configure `DASHBOARD_CACHE`, `DASHBOARD_LOCKS`, and `GITHUB_TOKEN` before deploying the Worker.
+The Worker in `worker/index.ts` serves both the static app shell and the generic owner API. It validates public GitHub owners, progressively builds a capped public dashboard from the 200 most recently pushed public repositories per owner in 12-repository batches, stores dashboards and repo fragments in KV, serves fresh cache for 1h, serves stale or partial cache while revalidating, and builds the root hot board from existing cached dashboards. A Durable Object binding prevents repeated cold requests from stampeding GitHub. Configure `DASHBOARD_CACHE`, `DASHBOARD_LOCKS`, and `GITHUB_TOKEN` before deploying the Worker.
 
 ### GitHub App Login
 

--- a/scripts/lib/dashboard.test.ts
+++ b/scripts/lib/dashboard.test.ts
@@ -280,9 +280,9 @@ test("dashboard project sorting handles dev issue and pull request counts numeri
 });
 
 test("worker builds root hot dashboard from cached dashboards", async () => {
-  const alphaKey = dashboardCacheKey({ owner: "alpha", schemaVersion: 4 });
-  const betaKey = dashboardCacheKey({ owner: "beta", schemaVersion: 4 });
-  const forksKey = dashboardCacheKey({ owner: "forks", includeForks: true, schemaVersion: 4 });
+  const alphaKey = dashboardCacheKey({ owner: "alpha", schemaVersion: 5 });
+  const betaKey = dashboardCacheKey({ owner: "beta", schemaVersion: 5 });
+  const forksKey = dashboardCacheKey({ owner: "forks", includeForks: true, schemaVersion: 5 });
   const env = {
     DASHBOARD_CACHE: kvStore({
       "hot:index:v3": JSON.stringify([alphaKey]),
@@ -337,7 +337,7 @@ test("worker builds root hot dashboard from cached dashboards", async () => {
           repoLimit: 200,
         },
       }),
-      [dashboardCacheKey({ owner: "gamma", schemaVersion: 4 })]: JSON.stringify(
+      [dashboardCacheKey({ owner: "gamma", schemaVersion: 5 })]: JSON.stringify(
         testDashboard("gamma", [
           testProject({
             owner: "gamma",
@@ -623,7 +623,7 @@ test("dashboard build records GitHub quota headers", async () => {
 });
 
 test("worker preserves cached quota metadata on fresh responses", async () => {
-  const key = dashboardCacheKey({ owner: "owner", schemaVersion: 4 });
+  const key = dashboardCacheKey({ owner: "owner", schemaVersion: 5 });
   const dashboard = testDashboard("owner", []);
   dashboard.generatedAt = new Date().toISOString();
   if (dashboard.cache) {
@@ -712,8 +712,8 @@ test("worker serves partial cached sources while combined dashboard rebuilds", a
       fetch: async () => new Response(null, { status: 409 }),
     }),
   };
-  const alphaKey = dashboardCacheKey({ owner: "alpha", schemaVersion: 4 });
-  const betaKey = dashboardCacheKey({ owner: "beta", schemaVersion: 4 });
+  const alphaKey = dashboardCacheKey({ owner: "alpha", schemaVersion: 5 });
+  const betaKey = dashboardCacheKey({ owner: "beta", schemaVersion: 5 });
 
   try {
     const response = await worker.fetch(
@@ -741,6 +741,97 @@ test("worker serves partial cached sources while combined dashboard rebuilds", a
     ]);
     assert.equal(body.totals.repos, 2);
     assert.equal(repoFetches, 0);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("worker progressively resumes large owner dashboard builds from partial cache", async () => {
+  const originalFetch = globalThis.fetch;
+  const repos = Array.from({ length: 25 }, (_, index) => {
+    const name = `repo-${String(index + 1).padStart(2, "0")}`;
+    return {
+      owner: { login: "big" },
+      name,
+      full_name: `big/${name}`,
+      description: null,
+      html_url: `https://github.com/big/${name}`,
+      default_branch: "main",
+      language: null,
+      stargazers_count: 0,
+      forks_count: 0,
+      open_issues_count: 0,
+      archived: false,
+      pushed_at: `2026-05-${String(25 - index).padStart(2, "0")}T00:00:00Z`,
+      updated_at: `2026-05-${String(25 - index).padStart(2, "0")}T00:00:00Z`,
+      fork: false,
+      private: false,
+    };
+  });
+  const waitUntil: Promise<unknown>[] = [];
+  const context = {
+    waitUntil: (promise: Promise<unknown>) => {
+      waitUntil.push(promise);
+    },
+  };
+  const env = { DASHBOARD_CACHE: kvStore() };
+
+  globalThis.fetch = async (input) => {
+    const url = new URL(String(input));
+    const path = url.pathname;
+    if (path === "/users/big") {
+      return Response.json({ login: "big", type: "User" });
+    }
+    if (path === "/users/big/repos") {
+      return Response.json(repos);
+    }
+    if (path.endsWith("/releases")) {
+      return Response.json([
+        {
+          tag_name: "v1.0.0",
+          name: null,
+          html_url: "https://github.com/big/repo/releases/v1.0.0",
+          draft: false,
+          published_at: "2026-05-01T00:00:00Z",
+        },
+      ]);
+    }
+    if (path.endsWith("/commits/main")) {
+      return Response.json({
+        sha: "abcdef123456",
+        commit: { committer: { date: "2026-05-02T00:00:00Z" } },
+      });
+    }
+    if (path.includes("/compare/")) {
+      return Response.json({
+        total_commits: 0,
+        html_url: "https://github.com/big/repo/compare",
+      });
+    }
+    if (path.endsWith("/pulls")) {
+      return Response.json([]);
+    }
+    if (path.endsWith("/check-runs")) {
+      return Response.json({ check_runs: [] });
+    }
+    throw new Error(`unexpected fetch ${path}`);
+  };
+
+  try {
+    const first = await worker.fetch(new Request("https://release.bar/api/big"), env, context);
+    const firstBody = (await first.json()) as DashboardPayload;
+    assert.equal(firstBody.cache?.state, "partial");
+    assert.equal(firstBody.cache?.progress?.scanned, 12);
+    assert.equal(firstBody.cache?.progress?.done, false);
+    assert.equal(firstBody.projects.length, 12);
+
+    await Promise.all(waitUntil.splice(0));
+
+    const second = await worker.fetch(new Request("https://release.bar/api/big"), env, context);
+    const secondBody = (await second.json()) as DashboardPayload;
+    assert.equal(secondBody.cache?.state, "fresh");
+    assert.equal(secondBody.cache?.progress?.done, true);
+    assert.equal(secondBody.projects.length, 25);
   } finally {
     globalThis.fetch = originalFetch;
   }
@@ -1600,18 +1691,18 @@ test("cache keys include owner, schema, and visibility flags", () => {
       includeForks: true,
       includeArchived: false,
       includeUnreleased: true,
-      schemaVersion: 4,
+      schemaVersion: 5,
     }),
-    "dashboard:v4:openclaw:forks-noarchived-unreleased",
+    "dashboard:v5:openclaw:forks-noarchived-unreleased",
   );
   assert.equal(
     dashboardCacheKey({
       owner: "openclaw",
       owners: ["Steipete"],
       repos: ["Steipete/Oracle"],
-      schemaVersion: 4,
+      schemaVersion: 5,
     }),
-    "dashboard:v4:openclaw:noforks-noarchived-released:sources-2dgec2fqc87xi",
+    "dashboard:v5:openclaw:noforks-noarchived-released:sources-2dgec2fqc87xi",
   );
   assert.equal(
     dashboardCacheKey({

--- a/scripts/lib/dashboard.ts
+++ b/scripts/lib/dashboard.ts
@@ -18,13 +18,20 @@ export type DashboardBuildOptions = {
   includeUnreleased?: boolean;
   excludeRepos?: string[];
   includeRepos?: string[];
+  initialProjects?: Project[];
+  skipRepos?: string[];
   repoLimit?: number;
   repoScanLimit?: number;
+  repoScanTarget?: number;
   token?: string;
   quotaSource?: ApiQuota["source"];
   quotaAccount?: string | null;
   fetch?: typeof fetch;
   projectCache?: ProjectCache;
+  onProgress?: (
+    payload: DashboardPayload,
+    progress: { scannedRepo: string; scanned: number; done: boolean },
+  ) => Promise<void> | void;
   log?: (message: string) => void;
 };
 
@@ -825,18 +832,83 @@ export async function buildDashboard(options: DashboardBuildOptions): Promise<Da
     options.quotaSource,
     options.quotaAccount ?? null,
   );
-  const projects: Project[] = [];
+  const projects: Project[] = [...(options.initialProjects ?? [])];
   let capped = false;
+  let scanIncomplete = false;
+  let scannedThisRun = 0;
   const seen = new Set<string>();
+  const skippedRepos = new Set((options.skipRepos ?? []).map((repo) => repo.toLowerCase()));
+  for (const project of projects) {
+    seen.add(project.fullName.toLowerCase());
+  }
+
+  function payload(state: NonNullable<DashboardPayload["cache"]>["state"]): DashboardPayload {
+    const sortedProjects = [...projects].sort((a, b) => {
+      const aDate = a.pushedAt ? Date.parse(a.pushedAt) : 0;
+      const bDate = b.pushedAt ? Date.parse(b.pushedAt) : 0;
+      return bDate - aDate;
+    });
+    const generatedAt = new Date().toISOString();
+    const released = projects.filter((project) => project.releaseDate).length;
+    const scanned = skippedRepos.size + scannedThisRun;
+    const progress = options.repoScanTarget
+      ? {
+          scanned,
+          limit: options.repoScanTarget,
+          done: state !== "partial" && !scanIncomplete,
+        }
+      : undefined;
+    return {
+      title: options.title,
+      subtitle: options.subtitle,
+      canonicalDomain: options.canonicalDomain,
+      generatedAt,
+      owners: options.owners,
+      options: {
+        includeForks: options.includeForks,
+        includeArchived: options.includeArchived,
+        includeUnreleased: Boolean(options.includeUnreleased),
+        repoLimit: options.repoLimit ?? null,
+      },
+      cache: {
+        state,
+        stale: state !== "fresh",
+        capped,
+        repoLimit: options.repoLimit ?? null,
+        generatedAt,
+        quota: client.quota,
+        ...(progress ? { progress } : {}),
+        ...(progress && !progress.done
+          ? {
+              message: `scanned ${progress.scanned}${progress.limit ? `/${progress.limit}` : ""} recently pushed repos; still updating`,
+            }
+          : capped && options.repoScanLimit
+            ? {
+                message: `scanned ${options.repoScanLimit} recently pushed repos per owner`,
+              }
+            : {}),
+      },
+      totals: {
+        repos: sortedProjects.length,
+        released,
+        unreleased: sortedProjects.length - released,
+        commitsSinceRelease: sortedProjects.reduce(
+          (sum, project) => sum + (project.commitsSinceRelease || 0),
+          0,
+        ),
+      },
+      projects: sortedProjects,
+    };
+  }
 
   async function addRepo(repo: GitHubRepo, countLabel: string, force = false): Promise<void> {
     if (projects.some((project) => project.fullName === repo.full_name)) {
       return;
     }
-    if ((!force && seen.has(repo.full_name)) || !filterRepo(repo, options)) {
+    if ((!force && seen.has(repo.full_name.toLowerCase())) || !filterRepo(repo, options)) {
       return;
     }
-    seen.add(repo.full_name);
+    seen.add(repo.full_name.toLowerCase());
     options.log?.(`fetch ${countLabel} ${repo.full_name}`);
     const includeUnreleased = Boolean(options.includeUnreleased);
     const cached = await readProjectCache(options.projectCache, repo, includeUnreleased);
@@ -854,23 +926,45 @@ export async function buildDashboard(options: DashboardBuildOptions): Promise<Da
   if (options.repoLimit) {
     for (const owner of options.owners) {
       const ownerStart = projects.length;
+      const ownerExisting = projects.filter(
+        (project) => project.owner.toLowerCase() === owner.login.toLowerCase(),
+      ).length;
       let scanned = 0;
       let page = 1;
       const scanLimit = options.repoScanLimit ?? Number.POSITIVE_INFINITY;
-      while (projects.length - ownerStart <= options.repoLimit && scanned < scanLimit) {
+      while (
+        ownerExisting + projects.length - ownerStart <= options.repoLimit &&
+        scanned < scanLimit
+      ) {
         const repos = await ownerRepos(client, owner, page);
         if (repos.length === 0) {
           break;
         }
         for (const repo of repos) {
+          if (skippedRepos.has(repo.full_name.toLowerCase())) {
+            continue;
+          }
           if (scanned >= scanLimit) {
             capped = true;
+            if (options.repoScanTarget) {
+              scanIncomplete = true;
+            }
             break;
           }
           scanned += 1;
-          const ownerCount = projects.length - ownerStart;
+          scannedThisRun += 1;
+          const ownerCount = ownerExisting + projects.length - ownerStart;
           await addRepo(repo, `${owner.login} ${ownerCount + 1}/${options.repoLimit}`);
-          if (projects.length - ownerStart > options.repoLimit) {
+          const progressPayload = payload("partial");
+          if (progressPayload.cache?.progress) {
+            progressPayload.cache.progress.done = false;
+          }
+          await options.onProgress?.(progressPayload, {
+            scannedRepo: repo.full_name,
+            scanned: skippedRepos.size + scannedThisRun,
+            done: false,
+          });
+          if (ownerExisting + projects.length - ownerStart > options.repoLimit) {
             capped = true;
             break;
           }
@@ -880,12 +974,15 @@ export async function buildDashboard(options: DashboardBuildOptions): Promise<Da
         }
         if (scanned >= scanLimit) {
           capped = true;
+          if (options.repoScanTarget) {
+            scanIncomplete = true;
+          }
           break;
         }
         page += 1;
       }
-      if (projects.length - ownerStart > options.repoLimit) {
-        projects.splice(ownerStart + options.repoLimit);
+      if (ownerExisting + projects.length - ownerStart > options.repoLimit) {
+        projects.splice(ownerStart + Math.max(0, options.repoLimit - ownerExisting));
       }
     }
   } else {
@@ -912,48 +1009,10 @@ export async function buildDashboard(options: DashboardBuildOptions): Promise<Da
     }
   }
 
-  projects.sort((a, b) => {
-    const aDate = a.pushedAt ? Date.parse(a.pushedAt) : 0;
-    const bDate = b.pushedAt ? Date.parse(b.pushedAt) : 0;
-    return bDate - aDate;
+  await options.onProgress?.(payload(scanIncomplete ? "partial" : "fresh"), {
+    scannedRepo: "",
+    scanned: skippedRepos.size + scannedThisRun,
+    done: !scanIncomplete,
   });
-
-  const generatedAt = new Date().toISOString();
-  const released = projects.filter((project) => project.releaseDate).length;
-  return {
-    title: options.title,
-    subtitle: options.subtitle,
-    canonicalDomain: options.canonicalDomain,
-    generatedAt,
-    owners: options.owners,
-    options: {
-      includeForks: options.includeForks,
-      includeArchived: options.includeArchived,
-      includeUnreleased: Boolean(options.includeUnreleased),
-      repoLimit: options.repoLimit ?? null,
-    },
-    cache: {
-      state: "fresh",
-      stale: false,
-      capped,
-      repoLimit: options.repoLimit ?? null,
-      generatedAt,
-      quota: client.quota,
-      ...(capped && options.repoScanLimit
-        ? {
-            message: `scanned ${options.repoScanLimit} recently pushed repos per owner`,
-          }
-        : {}),
-    },
-    totals: {
-      repos: projects.length,
-      released,
-      unreleased: projects.length - released,
-      commitsSinceRelease: projects.reduce(
-        (sum, project) => sum + (project.commitsSinceRelease || 0),
-        0,
-      ),
-    },
-    projects,
-  };
+  return payload(scanIncomplete ? "partial" : "fresh");
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -131,6 +131,11 @@ export type DashboardPayload = {
     generatedAt: string;
     quota?: ApiQuota;
     message?: string;
+    progress?: {
+      scanned: number;
+      limit: number | null;
+      done: boolean;
+    };
   };
   totals: {
     repos: number;

--- a/worker/index.ts
+++ b/worker/index.ts
@@ -86,10 +86,11 @@ const fullTtlMs = 60 * 60 * 1000;
 const staleTtlSeconds = 3 * 24 * 60 * 60;
 const installationTokenTtlSeconds = 50 * 60;
 const coldBuildWaitMs = 15 * 1000;
+const progressiveBuildBudgetMs = 25 * 1000;
 const buildLockTtlMs = 2 * 60 * 1000;
 const buildLockRefreshMs = 30 * 1000;
-const repoLimit = 12;
-const repoScanLimit = 12;
+const repoLimit = 200;
+const repoScanBatchSize = 12;
 const hotLimit = 50;
 const hotOwnerLimit = 3;
 const hotSourceLimit = 24;
@@ -98,8 +99,8 @@ const hotCacheTtlMs = 5 * 60 * 1000;
 const discoverLimit = 40;
 const discoverCacheTtlMs = 60 * 60 * 1000;
 const maxCustomSources = 8;
-const dashboardSchemaVersion = 4;
-const previousDashboardSchemaVersion = 3;
+const dashboardSchemaVersion = 5;
+const previousDashboardSchemaVersion = 4;
 const auxiliaryCacheSchemaVersion = 3;
 const dashboardCachePrefix = `dashboard:v${dashboardSchemaVersion}:`;
 const previousDashboardCachePrefix = `dashboard:v${previousDashboardSchemaVersion}:`;
@@ -152,6 +153,12 @@ type BuildLock = {
 type StoredBuildLock = {
   token: string;
   expiresAt: number;
+};
+
+type StoredBuildProgress = {
+  scannedRepos: string[];
+  projects: Project[];
+  updatedAt: string;
 };
 
 type AuthState = {
@@ -1102,6 +1109,7 @@ function withCacheState(
       repoLimit: payload.cache ? payload.cache.repoLimit : repoLimit,
       generatedAt: payload.generatedAt,
       ...(payload.cache?.quota ? { quota: payload.cache.quota } : {}),
+      ...(payload.cache?.progress ? { progress: payload.cache.progress } : {}),
       ...(cacheMessage ? { message: cacheMessage } : {}),
     },
   };
@@ -1198,6 +1206,29 @@ async function writeCached(
   await env.DASHBOARD_CACHE?.put(key, JSON.stringify(payload), {
     expirationTtl: ttlSeconds,
   });
+}
+
+function progressKey(key: string): string {
+  return `progress:v1:${key}`;
+}
+
+async function readProgress(env: Env, key: string): Promise<StoredBuildProgress | null> {
+  const raw = await env.DASHBOARD_CACHE?.get(progressKey(key));
+  if (!raw) return null;
+  const parsed = tryJsonParse<StoredBuildProgress>(raw, `progress ${key}`);
+  return parsed && Array.isArray(parsed.scannedRepos) && Array.isArray(parsed.projects)
+    ? parsed
+    : null;
+}
+
+async function writeProgress(env: Env, key: string, progress: StoredBuildProgress): Promise<void> {
+  await env.DASHBOARD_CACHE?.put(progressKey(key), JSON.stringify(progress), {
+    expirationTtl: staleTtlSeconds,
+  });
+}
+
+async function deleteProgress(env: Env, key: string): Promise<void> {
+  await env.DASHBOARD_CACHE?.delete?.(progressKey(key));
 }
 
 function projectActivityDate(project: Project): string | null {
@@ -1757,6 +1788,21 @@ async function rebuild(dashboard: DashboardRequest, env: Env): Promise<Dashboard
   }
 
   const promise = (async () => {
+    const storedProgress = await readProgress(env, dashboard.key);
+    const scannedRepos = new Set(storedProgress?.scannedRepos ?? []);
+    const progressProjects = storedProgress?.projects ?? [];
+    const saveProgress = async (payload: DashboardPayload, scannedRepo: string) => {
+      if (scannedRepo) {
+        scannedRepos.add(scannedRepo.toLowerCase());
+      }
+      const profiled = withProfile(payload, dashboard.profile);
+      await writeCached(env, dashboard.key, profiled);
+      await writeProgress(env, dashboard.key, {
+        scannedRepos: [...scannedRepos],
+        projects: profiled.projects,
+        updatedAt: profiled.generatedAt,
+      });
+    };
     const payload = await buildDashboard({
       title: "ReleaseBar",
       subtitle: dashboard.subtitle,
@@ -1766,17 +1812,30 @@ async function rebuild(dashboard: DashboardRequest, env: Env): Promise<Dashboard
       excludeRepos: dashboard.profile?.hiddenRepos,
       ...optionsFromUrl(dashboard.url),
       repoLimit,
-      repoScanLimit,
+      repoScanLimit: repoScanBatchSize,
+      repoScanTarget: repoLimit,
+      initialProjects: progressProjects,
+      skipRepos: [...scannedRepos],
       token: dashboard.token ?? env.GITHUB_TOKEN,
       quotaSource:
         dashboard.quotaSource ?? (dashboard.token || env.GITHUB_TOKEN ? "shared" : "anonymous"),
       quotaAccount: dashboard.quotaAccount ?? null,
       fetch: workerFetch,
       projectCache: env.DASHBOARD_CACHE,
+      onProgress: (partial, progress) => saveProgress(partial, progress.scannedRepo),
     });
     const profiled = withProfile(payload, dashboard.profile);
     await writeCached(env, dashboard.key, profiled);
-    await rememberHotDashboard(env, dashboard.key, profiled);
+    if (profiled.cache?.progress?.done === false) {
+      await writeProgress(env, dashboard.key, {
+        scannedRepos: [...scannedRepos],
+        projects: profiled.projects,
+        updatedAt: profiled.generatedAt,
+      });
+    } else {
+      await deleteProgress(env, dashboard.key);
+      await rememberHotDashboard(env, dashboard.key, profiled);
+    }
     return profiled;
   })();
 
@@ -1805,6 +1864,17 @@ async function rebuildWithBuildLock(
   } finally {
     globalThis.clearInterval(refresh);
     await lock.release();
+  }
+}
+
+async function continueProgressiveBuild(dashboard: DashboardRequest, env: Env): Promise<void> {
+  const startedAt = Date.now();
+  let payload = await rebuildWithBuildLock(dashboard, env);
+  while (
+    payload?.cache?.progress?.done === false &&
+    Date.now() - startedAt < progressiveBuildBudgetMs
+  ) {
+    payload = await rebuildWithBuildLock(dashboard, env);
   }
 }
 
@@ -2039,7 +2109,7 @@ async function ownerResponse(
     });
   }
 
-  if (cached && ageMs < fullTtlMs) {
+  if (cached && cached.cache?.progress?.done !== false && ageMs < fullTtlMs) {
     return jsonResponse(withCacheState(cached, "fresh"));
   }
 
@@ -2049,10 +2119,11 @@ async function ownerResponse(
         .catch(() => null)
         .then((token) => {
           const dashboard = cachedDashboardRequest(cached, includeRepos, key, url, token);
-          return rebuildWithBuildLock(dashboard, env).catch(() => undefined);
+          return continueProgressiveBuild(dashboard, env).catch(() => undefined);
         }),
     );
-    return jsonResponse(withCacheState(cached, "stale"));
+    const state = cached.cache?.progress?.done === false ? "partial" : "stale";
+    return jsonResponse(withCacheState(cached, state));
   }
 
   const token = await requestToken().catch(() => null);
@@ -2088,7 +2159,21 @@ async function ownerResponse(
       }),
     ]);
     if (payload === buildPending || payload === null) {
-      context.waitUntil(build.catch((error) => cacheBuildError(dashboard, env, error)));
+      context.waitUntil(
+        build
+          .then((built) =>
+            built?.cache?.progress?.done === false
+              ? continueProgressiveBuild(dashboard, env)
+              : undefined,
+          )
+          .catch((error) => cacheBuildError(dashboard, env, error)),
+      );
+      const progressive = await readCached(env, key);
+      if (progressive?.projects.length) {
+        return jsonResponse(withCacheState(progressive, "partial"), 200, {
+          "cache-control": "no-store",
+        });
+      }
       const partial = await partialDashboardPayload(dashboard, env, ownerSlugs);
       if (partial) {
         return jsonResponse(partial, 200, {
@@ -2098,6 +2183,9 @@ async function ownerResponse(
       return jsonResponse(rebuildingPayload(dashboard, env), 202, {
         "cache-control": "no-store",
       });
+    }
+    if (payload.cache?.progress?.done === false) {
+      context.waitUntil(continueProgressiveBuild(dashboard, env).catch(() => undefined));
     }
     return jsonResponse(payload);
   } catch (error) {


### PR DESCRIPTION
## Summary
- progressively cache large owner dashboards in 12-repository batches up to the 200-repo cap
- serve partial cached data immediately while Worker waitUntil continues the scan
- persist build progress separately so later requests resume instead of restarting
- bump dashboard cache schema to avoid reusing old 12-repo owner caches as complete

## Verification
- npm run check:static
- codex-review --parallel-tests "npm run check:static"
