### PR TITLE
fix: keep progressive dashboard responses uncached

### DIFF
--- a/scripts/lib/dashboard.test.ts
+++ b/scripts/lib/dashboard.test.ts
@@ -733,6 +733,7 @@ test("worker serves partial cached sources while combined dashboard rebuilds", a
       { waitUntil: () => undefined },
     );
     assert.equal(response.status, 200);
+    assert.equal(response.headers.get("cache-control"), "no-store");
     const body = (await response.json()) as DashboardPayload;
     assert.equal(body.cache?.state, "partial");
     assert.deepEqual(body.projects.map((project) => project.fullName).sort(), [
@@ -820,6 +821,7 @@ test("worker progressively resumes large owner dashboard builds from partial cac
   try {
     const first = await worker.fetch(new Request("https://release.bar/api/big"), env, context);
     const firstBody = (await first.json()) as DashboardPayload;
+    assert.equal(first.headers.get("cache-control"), "no-store");
     assert.equal(firstBody.cache?.state, "partial");
     assert.equal(firstBody.cache?.progress?.scanned, 12);
     assert.equal(firstBody.cache?.progress?.done, false);

--- a/worker/index.ts
+++ b/worker/index.ts
@@ -2123,7 +2123,9 @@ async function ownerResponse(
         }),
     );
     const state = cached.cache?.progress?.done === false ? "partial" : "stale";
-    return jsonResponse(withCacheState(cached, state));
+    return jsonResponse(withCacheState(cached, state), 200, {
+      "cache-control": "no-store",
+    });
   }
 
   const token = await requestToken().catch(() => null);
@@ -2186,6 +2188,9 @@ async function ownerResponse(
     }
     if (payload.cache?.progress?.done === false) {
       context.waitUntil(continueProgressiveBuild(dashboard, env).catch(() => undefined));
+      return jsonResponse(payload, 200, {
+        "cache-control": "no-store",
+      });
     }
     return jsonResponse(payload);
   } catch (error) {


### PR DESCRIPTION
## Summary
- mark partial/stale owner dashboard API responses `no-store` so every refresh can re-enter the Worker and resume the progressive scan
- keep fresh dashboard responses on the normal public cache path
- add regression assertions for partial response cache headers

## Verification
- npm run check:static
- codex-review --parallel-tests "npm run check:static"
- live `/api/microsoft` exposed partial progress stuck at 12/200 before this fix because the partial JSON was edge-cacheable
