### PR TITLE
fix: keep long versions inside table cells

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Added a GitHub Hot root dashboard backed by cached GitHub repository search, with today/week/month/year and language filters.
 - Progressively cache API owner scans in 12-repository batches so huge organizations show rows while the dashboard keeps updating.
+- Improved version-column wrapping so long release tags do not collide with release dates in dev mode.
 - Made project owners link to their ReleaseBar dashboards while repository names still open GitHub.
 - Show cached partial source data while cold combined dashboards rebuild in the background.
 - Added owner-only public dashboard defaults so saved sources and visibility apply at clean owner URLs.

--- a/src/styles.css
+++ b/src/styles.css
@@ -892,6 +892,18 @@ body.dev-mode .dev-only {
   font-size: 12px;
 }
 
+.version-cell {
+  overflow: hidden;
+}
+
+.version-cell a {
+  display: block;
+  max-width: 100%;
+  padding-right: 6px;
+  overflow-wrap: anywhere;
+  line-height: 1.16;
+}
+
 .since-cell a,
 .since-cell {
   color: var(--amber);


### PR DESCRIPTION
## Summary
- keep long release/version tags constrained inside the version column
- allow emergency wrapping for scoped package tags while preserving table boundaries
- add changelog note for the visible table polish

## Verification
- npm run check:static
- codex-review --parallel-tests "npm run check:static"
- headless Chrome fixture for `@fluentui/theme-samples_v8.7.225` in dev-mode table row
