### PR TITLE
feat: link owner subtitle and show account avatar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## Unreleased
 
 - Added a GitHub Hot root dashboard backed by cached GitHub repository search, with today/week/month/year and language filters.
+- Show signed-in GitHub avatars in the account menu trigger.
+- Linked single-owner dashboard subtitles to the GitHub user or organization.
 - Progressively cache API owner scans in 12-repository batches so huge organizations show rows while the dashboard keeps updating.
 - Improved version-column wrapping so long release tags do not collide with release dates in dev mode.
 - Made project owners link to their ReleaseBar dashboards while repository names still open GitHub.

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -89,6 +89,16 @@
 
   $: label = data ? ownerLabel(data) : initialRoute.label;
   $: subtitle = data?.subtitle ?? "Release debt across recently requested public dashboards.";
+  $: profileSourceCount =
+    (data?.profile?.includeOwners.length ?? 0) + (data?.profile?.includeRepos.length ?? 0);
+  $: subtitleOwner =
+    !initialRoute.isDefault &&
+    initialRoute.owner &&
+    initialRoute.extraOwners.length === 0 &&
+    initialRoute.repos.length === 0 &&
+    (!data || (data.owners.length === 1 && profileSourceCount === 0))
+      ? (data?.owners[0]?.login ?? initialRoute.owner)
+      : null;
   $: includeArchived = data?.options?.includeArchived === true;
   $: visibleProjects = data
     ? data.projects.filter((project) =>
@@ -857,7 +867,16 @@
     <div>
       <a class="eyebrow" href="/">ReleaseBar</a>
       <h1>{label}</h1>
-      <p class="subtitle">{subtitle}</p>
+      <p class="subtitle">
+        {#if subtitleOwner}
+          Release freshness for
+          <a class="subtitle-link" href={`https://github.com/${subtitleOwner}`} target="_blank" rel="noreferrer">
+            @{subtitleOwner}</a
+          >.
+        {:else}
+          {subtitle}
+        {/if}
+      </p>
     </div>
     <div class="top-actions">
       <button
@@ -875,6 +894,7 @@
       {#if auth?.user}
         <DropdownMenu.Root>
           <DropdownMenu.Trigger class="account-button">
+            <img class="account-avatar" src={auth.user.avatarUrl} alt="" width="24" height="24" loading="lazy" />
             <span class="account-label">@{auth.user.login}</span>
             <span class="account-caret" aria-hidden="true"></span>
           </DropdownMenu.Trigger>

--- a/src/styles.css
+++ b/src/styles.css
@@ -19,7 +19,7 @@
   /* Shape */
   --radius: 8px;
   --control-height: 36px;
-  --account-width: clamp(136px, 18vw, 220px);
+  --account-width: clamp(176px, 18vw, 240px);
   --shadow: 0 18px 80px rgba(0, 0, 0, 0.45);
 
   font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
@@ -77,6 +77,19 @@ a:hover {
   color: var(--muted);
   font-size: 14px;
   line-height: 1.5;
+}
+
+.subtitle-link {
+  color: var(--text);
+  text-decoration-color: var(--line-strong);
+  text-decoration-thickness: 1px;
+  text-underline-offset: 4px;
+}
+
+.subtitle-link:hover,
+.subtitle-link:focus-visible {
+  color: var(--green);
+  text-decoration-color: currentColor;
 }
 
 .eyebrow {
@@ -393,14 +406,25 @@ button:focus-visible {
 
 .account-button {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) auto minmax(0, 1fr);
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  column-gap: 8px;
   width: var(--account-width);
   max-width: calc(100vw - 32px);
   flex: 0 0 auto;
   align-items: center;
   border-color: var(--line-strong);
-  padding: 0 14px;
+  padding: 0 12px;
   color: var(--text);
+}
+
+.account-avatar {
+  grid-column: 1;
+  width: 24px;
+  height: 24px;
+  border: 1px solid rgba(232, 244, 223, 0.28);
+  border-radius: 50%;
+  object-fit: cover;
+  background: var(--panel-2);
 }
 
 .account-label {
@@ -410,6 +434,7 @@ button:focus-visible {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+  text-align: center;
 }
 
 .account-caret {


### PR DESCRIPTION
## Summary
- show the signed-in GitHub avatar inside the account menu trigger
- link single-owner dashboard subtitles to that GitHub user or organization
- keep multi-source dashboards on the broader source-count subtitle

## Verification
- npm run check:static
- codex-review --parallel-tests "npm run check:static"
- headless Chrome fixture for the avatar account chip
