### PR TITLE
feat: add stargazer trust analysis

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,4 +10,5 @@ Work style: terse.
 - Required GitHub secret: `CLOUDFLARE_API_TOKEN`.
 - Post-deploy smoke compares live JS/CSS hashes against local `dist/index.html`, then checks `/`, `/steipete`, `/openclaw/openclaw`, and `/api/_discover`.
 - Local prod deploy: `npx wrangler deploy`.
+- Local real-data dev: `npm run dev:worker:real` uses Wrangler `--remote` on port 8787 with real secrets and preview KV.
 - Static CI/proof: `npm run check:static`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,16 @@
 ## Unreleased
 
 - Embed cached public dashboard and repository payloads in served app shells so warm routes render without an initial loading panel.
+- Added OpenAPI/Swagger JSON endpoints for the public trust and audience APIs.
+- Refined trust UI labels, audience percentage summaries, contributor score pills, and external-link markers.
+- Documented the public REST API contract for cached trust profiles and repository audience signals, including agent PR-triage guidance.
+- Added repository audience analysis from recent public stargazers, with week/month filters, cached trust/klout dimensions, public org signals, and recent repo evidence.
+- Added bounded GitHub trust profiles to owner pages with account age, score dimensions, public orgs, and recent repository evidence.
+- Added weighted trust-score factors so profile scores show the age, profile, org, reach, builder, recency, and account-safety inputs behind the number.
+- Rebalanced trust scoring around trust, builder, reach, and positive account safety, dropping repository fit from the surfaced score.
+- Added GitHub App-only audience backfill for repository stargazer trust caches, keeping batch warming off shared API quota.
+- Moved detailed trust scoring into a profile tab and kept a compact trust snapshot on the main owner page.
+- Skipped release hydration on unsynced public dashboards so stargazer profile links do not burn shared GitHub API quota.
 - Clarify repository activity summaries by showing the selected activity range instead of a misleading commit count.
 - Show repository names in full in repository detail hero titles, with owner context kept in the breadcrumb/avatar.
 - Renamed the header wordmark and page-title suffix from `ReleaseBar` to `release.bar` to match the domain.

--- a/README.md
+++ b/README.md
@@ -89,6 +89,27 @@ wrangler secret put OPENAI_API_KEY
 
 Summaries are generated server-side through the OpenAI Responses API without an explicit reasoning option. Release summaries are cached by repository, release tag, default-branch head SHA, model, and prompt version; activity summaries also refresh when the configured model changes.
 
+## Local Real-Data Testing
+
+Use Wrangler remote dev when you need local code with real Cloudflare execution, GitHub App secrets, and OpenAI/GitHub tokens:
+
+```sh
+npm run dev:worker:real
+```
+
+Open `http://localhost:8787/steipete` or any other route. This runs the current checkout on Cloudflare, so cold dashboards can use the same GitHub App credentials and real API paths as `release.bar`.
+
+For frontend hot reload, run both processes:
+
+```sh
+npm run dev
+npm run dev:worker:real
+```
+
+The Vite app falls back to `http://127.0.0.1:8787` for API calls. `npm run dev:worker` stays fully local and is useful for UI shape and tests, but it does not have production secrets unless you provide local `.dev.vars`.
+
+Because `wrangler.toml` defines a KV `preview_id`, remote dev uses the preview KV namespace instead of the production cache. It can fetch real data and warm that preview cache without mutating the live `release.bar` cache.
+
 ## Deploy
 
 The combined app/API Worker deploys with Wrangler through `.github/workflows/deploy.yml` on pushes to `main`:

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Release freshness dashboard for public GitHub users and orgs.
 
-ReleaseBar tracks public GitHub repository release health: latest version, release date, commits since release, activity, stars, language, topics, open work, and CI status. It serves cached dashboards for routes like `https://release.bar/steipete`, `https://release.bar/openclaw`, and `https://release.bar/microsoft`.
+ReleaseBar tracks public GitHub repository release health: latest version, release date, commits since release, activity, stars, language, topics, open work, CI status, and recent stargazer audience signals. It serves cached dashboards for routes like `https://release.bar/steipete`, `https://release.bar/openclaw`, and `https://release.bar/microsoft`.
 
 Owner dashboards show visible public repositories immediately with lightweight repo metadata, then progressively hydrate release, commit, PR, and CI data in the background.
 
@@ -37,22 +37,29 @@ Set `GITHUB_TOKEN` for higher API limits. GitHub Actions uses the built-in token
 - settings can hide visible owners or repos locally without changing the shared cache
 - GitHub App login uses `/api/auth/login`, `/api/auth/callback`, `/api/auth/install`, `/api/auth/logout`, and `/api/me`
 - `Connect GitHub` signs the user in, checks GitHub App installations, and sends them to install the app when the current dashboard source is not covered
+- GitHub App installation gives ReleaseBar dedicated GitHub API quota for the selected account/repositories; public unsynced dashboards stay metadata-only and skip release hydration
+- repository audience backfill is GitHub App-only and warms bounded week/month stargazer trust caches for covered repositories
 - GitHub App installation gives ReleaseBar dedicated GitHub API quota for the selected account/repositories; once an account installation is known, public refreshes for that account can use its app quota even for anonymous viewers
 - private repositories are ignored even when selected in GitHub App installation; ReleaseBar only stores and renders public repository metadata
 - the need-attention metric filters repos with unreleased commits, stale releases, failing/cancelled CI, or issue/PR pressure and rows show the reason inline
-- repository detail pages include release cadence, recent releases, contributors, languages, commit/churn charts, and 30-day issue/PR trend counts when GitHub provides them
+- owner pages show bounded people trust or org signal profiles with GitHub age, reach, footprint, safety dimensions, weighted score factors, and recent repository evidence
+- repository detail pages include release cadence, recent releases, contributors, languages, commit/churn charts, recent public stargazer audience signals, and 30-day issue/PR trend counts when GitHub provides them
 - repository detail pages can show an AI summary of commit titles since the latest release when the Worker has an OpenAI API key
 
 ## API And Cache
 
-The Worker in `worker/index.ts` serves both the static app shell and the generic owner API:
+The Worker in `worker/index.ts` serves both the static app shell and the generic owner API. See [docs/api.md](docs/api.md) for the public REST contract, response shapes, cache semantics, and agent PR-triage guidance.
 
 - `GET /api/:owner` returns a cached dashboard for a public GitHub user or org
 - `GET /api/:owner/events` streams cache updates for progressive rebuilds
+- `GET /api/users/:login/trust` returns cached public people trust or organization signal scoring, account age, score dimensions, and weighted score factors for one GitHub profile
 - `GET /api/repos/:owner/:repo` returns repository detail stats
+- `GET /api/repos/:owner/:repo/audience?range=week|month` returns cached recent stargazer scoring from public GitHub profile fields
+- `POST /api/repos/:owner/:repo/audience/backfill` warms bounded week/month stargazer trust caches with GitHub App quota only
+- `GET /openapi.json`, `GET /api/openapi.json`, and `GET /api/swagger.json` expose the public API as Swagger-compatible OpenAPI 3.1 JSON
 - `GET /api/_discover` and `GET /api/_hot` power the root dashboard
 
-Dashboard builds validate public GitHub owners, scan up to the 200 most recently pushed public repositories per owner, and hydrate repositories in 12-repository batches. Dashboard payloads, repo fragments, hot boards, app-installation coverage, profile settings, and auth session data live in Cloudflare KV. A Durable Object binding (`DASHBOARD_LOCKS`) prevents repeated cold requests from stampeding GitHub.
+Dashboard builds validate public GitHub owners and scan up to the 200 most recently pushed public repositories per owner. Release hydration runs in 12-repository batches only when the dashboard is backed by GitHub App quota; unsynced public dashboards show bounded repository metadata without release, compare, commit, or check-run calls. Dashboard payloads, repo fragments, hot boards, app-installation coverage, profile settings, and auth session data live in Cloudflare KV. A Durable Object binding (`DASHBOARD_LOCKS`) prevents repeated cold requests from stampeding GitHub.
 
 Fresh dashboard cache is served for about 1h. Stale or partial cache is shown while a background rebuild continues, so large owners can show useful rows before all release data finishes. Dashboard records are retained longer than the fresh window so older public data can remain visible during GitHub outages or rate limits, with the UI marking stale/partial state.
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,343 @@
+# ReleaseBar Public API
+
+ReleaseBar exposes cached public REST endpoints for agents and dashboards that need GitHub release, people trust, and organization signal context without crawling the whole GitHub graph themselves.
+
+The trust and org signal APIs only use public GitHub profile, organization, repository, and stargazer metadata. They do not prove identity, employment, repository ownership, or maintainer intent. Treat the score as triage context, not an access-control decision.
+
+## Base URL
+
+```text
+https://release.bar
+```
+
+Local development may serve the app from Vite and the Worker API from Wrangler. Browser fallback routes use port `8787` for local Worker API calls.
+
+## OpenAPI
+
+Swagger-compatible OpenAPI 3.1 JSON is available at:
+
+- `GET /openapi.json`
+- `GET /api/openapi.json`
+- `GET /api/swagger.json`
+
+## Cache Contract
+
+All successful JSON responses include a `cache` object when the payload can be reused by agents.
+
+```ts
+type CacheState = {
+  state: "fresh" | "stale" | "partial" | "warming" | "error";
+  stale: boolean;
+  generatedAt: string;
+  message?: string;
+  quota?: {
+    source: "app" | "shared" | "anonymous";
+    account: string | null;
+    remaining: number | null;
+    limit: number | null;
+    resetAt: string | null;
+    resource: string | null;
+  };
+};
+```
+
+Agents should:
+
+- prefer `fresh` and `stale` payloads over calling GitHub directly
+- keep their own short client cache keyed by endpoint URL
+- surface `cache.stale`, `cache.generatedAt`, and `cache.message` in audit logs
+- avoid retry loops on `429`; respect `Retry-After` when present
+- treat `error` payloads as "no ReleaseBar signal", not as negative user evidence
+
+## User Trust Or Org Signal Profile
+
+`GET /api/users/:login/trust`
+
+Returns a cached public people trust profile or organization signal profile for one GitHub login. This is the primary agent endpoint for PR triage when an agent wants bounded context about an author, reviewer, issue reporter, commenter, or the organization behind a repository.
+
+People return `profileKind: "user_trust"` and `scoreLabel: "trust score"`. Organization accounts return `profileKind: "org_signal"` and `scoreLabel: "org signal"` because an organization is a project venue, employer, brand, or umbrella rather than an individual actor. Do not present an org signal as personal author trust.
+
+### Path Parameters
+
+| Name    | Type   | Notes                                           |
+| ------- | ------ | ----------------------------------------------- |
+| `login` | string | GitHub login. `@` prefixes are normalized away. |
+
+### Response
+
+```ts
+type TrustProfilePayload = {
+  login: string;
+  type: "user" | "org";
+  profileKind: "user_trust" | "org_signal";
+  scoreLabel: "trust score" | "org signal";
+  avatarUrl: string;
+  url: string;
+  name: string | null;
+  company: string | null;
+  bio: string | null;
+  location: string | null;
+  blog: string | null;
+  twitterUsername: string | null;
+  followers: number;
+  following: number;
+  publicRepos: number;
+  publicGists: number;
+  accountCreatedAt: string | null;
+  accountUpdatedAt: string | null;
+  accountAgeDays: number | null;
+  score: number;
+  tier: "high" | "medium" | "low" | "bot";
+  reasons: string[];
+  dimensions: {
+    trust: number;
+    influence: number;
+    builder: number;
+    recency: number;
+    risk: number;
+  };
+  factors: Array<{
+    key: "age" | "profile" | "orgs" | "reach" | "builder" | "recency" | "risk";
+    label: string;
+    value: number;
+    maxValue: number;
+    weight: number;
+    weightedValue: number;
+    detail: string;
+    sentiment: "positive" | "neutral" | "negative";
+  }>;
+  orgs: Array<{
+    login: string;
+    description: string | null;
+  }>;
+  topRepositories: Array<{
+    fullName: string;
+    url: string;
+    description: string | null;
+    language: string | null;
+    stars: number;
+    forks: number;
+    updatedAt: string | null;
+    topics: string[];
+  }>;
+  stats: {
+    totalStars: number;
+    totalForks: number;
+    recentRepositories: number;
+    activeRepositories: number;
+    publicOrganizations: number;
+    languages: Array<{ name: string; count: number }>;
+    topics: Array<{ name: string; count: number }>;
+  };
+  generatedAt: string;
+  cache: CacheState;
+};
+```
+
+### Score Semantics
+
+`score` is a 0-100 public-signal score. `tier` is derived from that score, except obvious automation accounts return `bot`.
+
+For `profileKind: "user_trust"`, the score describes a person/account as a public GitHub actor. For `profileKind: "org_signal"`, the score describes an organization's public footprint and credibility. These are intentionally not the same semantic label.
+
+Dimension notes:
+
+- `trust`: for people, account age, profile completeness, and public organization signals; for orgs, organization credibility
+- `influence`: follower count and stars across recent public repositories
+- `builder`: for people, public repository history and recent activity; for orgs, public repository footprint
+- `recency`: stargazer recency when scored in a repository audience context; usually neutral on profile-only trust pages
+- `risk`: account safety score where `100` is best and lower values mean more public-account risk signals. The UI labels this as account safety to avoid implying a higher value is more risk.
+
+Agents should use the dimensions, factors, and reasons instead of only the headline score. A low score on a new account is not automatically suspicious; it may simply mean there is not enough public signal.
+
+### Example
+
+```sh
+curl -s https://release.bar/api/users/octocat/trust
+```
+
+```json
+{
+  "login": "octocat",
+  "type": "user",
+  "profileKind": "user_trust",
+  "scoreLabel": "trust score",
+  "accountAgeDays": 6200,
+  "score": 73,
+  "tier": "high",
+  "reasons": ["established GitHub audience", "active public builder"],
+  "dimensions": {
+    "trust": 68,
+    "influence": 74,
+    "builder": 80,
+    "recency": 0,
+    "risk": 100
+  },
+  "cache": {
+    "state": "fresh",
+    "stale": false,
+    "generatedAt": "2026-05-18T10:00:00.000Z"
+  }
+}
+```
+
+## Repository Audience
+
+`GET /api/repos/:owner/:repo/audience?range=week|month`
+
+Returns cached public trust scores for recent human stargazers of a repository. This is useful when an agent wants to understand who is newly showing interest in a project, not when it only needs one user's profile.
+
+If the deployment has GitHub App quota configured and the repository is not covered by the signed-in user's installation, cold audience builds are blocked. Existing cached audience payloads can still be returned as stale public context.
+
+### Query Parameters
+
+| Name    | Type                  | Default   | Notes                                   |
+| ------- | --------------------- | --------- | --------------------------------------- |
+| `range` | `"week"` or `"month"` | `"month"` | Filters recent stargazers by star time. |
+
+### Response
+
+```ts
+type RepoAudiencePayload = {
+  fullName: string;
+  range: "week" | "month";
+  generatedAt: string;
+  cache: CacheState;
+  totals: {
+    stargazers: number;
+    stargazersSampled: number;
+    highSignal: number;
+    mediumSignal: number;
+    lowSignal: number;
+    bots: number;
+    highSignalPercent: number;
+    mediumSignalPercent: number;
+    lowSignalPercent: number;
+    botPercent: number;
+  };
+  users: Array<{
+    login: string;
+    avatarUrl: string;
+    url: string;
+    name: string | null;
+    company: string | null;
+    bio: string | null;
+    location: string | null;
+    followers: number;
+    publicRepos: number;
+    starredAt: string | null;
+    accountCreatedAt: string | null;
+    score: number;
+    tier: "high" | "medium" | "low" | "bot";
+    // Present only when a cached UserTrustProfile exists for this login.
+    trustScore?: number;
+    trustTier?: "high" | "medium" | "low" | "bot";
+    reasons: string[];
+    dimensions: TrustProfilePayload["dimensions"];
+    factors: TrustProfilePayload["factors"];
+    orgs: TrustProfilePayload["orgs"];
+    topRepositories: Array<{
+      fullName: string;
+      url: string;
+      description: string | null;
+      language: string | null;
+      stars: number;
+      forks: number;
+      updatedAt: string | null;
+    }>;
+  }>;
+};
+```
+
+`score` and `tier` are contextual audience signals for this repository and star event. `trustScore` and `trustTier`, when present, come from the cached `UserTrustProfile` for the login and match `/api/users/{login}/trust`.
+
+## Audience Backfill
+
+`POST /api/repos/:owner/:repo/audience/backfill`
+
+Warms week and month repository audience caches. This endpoint requires GitHub App installation quota for the repository and is intended for covered dashboards, not anonymous broad crawling.
+
+### Response
+
+```ts
+type RepoAudienceBackfillPayload = {
+  fullName: string;
+  ranges: Array<{
+    range: "week" | "month";
+    state: "busy" | "fresh" | "rebuilt";
+    users: number;
+    generatedAt: string;
+  }>;
+  quota: {
+    source: "app";
+    account: string | null;
+  };
+  message: string;
+};
+```
+
+## PR Triage Guidance For Agents
+
+For a pull request, fetch the people trust profile for bounded actors only:
+
+- PR author
+- commit authors if different from the PR author
+- first-time reviewers or commenters that change the risk picture
+
+Suggested triage summary:
+
+```text
+author trust: medium 57
+age: 820 days
+builder: 64
+account safety: 92
+signals: active public builder; filled-out public profile; 12 public repos
+cache: stale, generated 2026-05-18T10:00:00.000Z
+```
+
+If the PR context is mostly organizational, label it separately:
+
+```text
+repo org signal: high 82
+footprint: 74
+reach: 69
+signals: organization account; 44 public repos; 12 recently active repos
+cache: fresh, generated 2026-05-18T10:00:00.000Z
+```
+
+Agent rules:
+
+- Do not block or approve a PR based only on ReleaseBar score.
+- Do not call this "verified" identity or employment.
+- Do not call an organization score "trust"; use `scoreLabel` or `profileKind` when rendering summaries.
+- Do not fan out across every commenter on large threads unless the task explicitly asks for that breadth.
+- Prefer `accountAgeDays`, `dimensions.risk`, `factors`, and `reasons` when explaining why a score matters.
+- For obvious automation accounts, preserve the `bot` tier and avoid treating low score as human-risk evidence.
+- When the endpoint returns stale cached data, say it is stale and continue if it is still useful context.
+- When the endpoint returns an error, omit trust context rather than retrying aggressively.
+
+## Error Responses
+
+Errors are JSON and usually include either `error` or `cache.message`.
+
+| Status | Meaning                                                                         |
+| ------ | ------------------------------------------------------------------------------- |
+| `400`  | Invalid owner, repository, or user slug.                                        |
+| `403`  | GitHub App quota is required for the requested cold audience build or backfill. |
+| `404`  | GitHub did not find the requested public resource.                              |
+| `429`  | GitHub shared quota is exhausted or secondary rate-limited.                     |
+| `502`  | Upstream API or payload-shape failure.                                          |
+
+Example:
+
+```json
+{
+  "error": "GitHub shared API quota is exhausted. Connect GitHub and install the app for this account to use dedicated quota, or try again after the shared quota resets.",
+  "cache": {
+    "state": "error",
+    "stale": true,
+    "generatedAt": "2026-05-18T10:00:00.000Z",
+    "message": "GitHub shared API quota is exhausted. Connect GitHub and install the app for this account to use dedicated quota, or try again after the shared quota resets."
+  }
+}
+```

--- a/package.json
+++ b/package.json
@@ -13,6 +13,8 @@
     "check:data": "node node_modules/.cache/releasebar-build/scripts/build.js --check",
     "check:static": "npm run typecheck && npm run lint && npm run format:check && npm run build:script && npm run build:app && npm run build:assets && npm run test",
     "dev": "vite dev --host 127.0.0.1",
+    "dev:worker": "npm exec --yes --package wrangler -- wrangler dev --port 8787",
+    "dev:worker:real": "npm exec --yes --package wrangler -- wrangler dev --remote --port 8787",
     "format": "oxfmt .",
     "format:check": "oxfmt --check .",
     "lint": "oxlint .",

--- a/scripts/lib/audience.ts
+++ b/scripts/lib/audience.ts
@@ -1,0 +1,455 @@
+export type AudienceScoreTier = "high" | "medium" | "low" | "bot";
+
+export type AudienceOrgSignal = {
+  login: string;
+  description: string | null;
+};
+
+export type AudienceRepoSignal = {
+  fullName: string;
+  description: string | null;
+  url: string;
+  language: string | null;
+  stars: number;
+  forks: number;
+  updatedAt: string | null;
+  pushedAt: string | null;
+  topics: string[];
+};
+
+export type AudienceScoreDimensions = {
+  trust: number;
+  influence: number;
+  builder: number;
+  recency: number;
+  risk: number;
+};
+
+export type AudienceScoreFactorKey =
+  | "age"
+  | "profile"
+  | "orgs"
+  | "reach"
+  | "builder"
+  | "recency"
+  | "risk";
+
+export type AudienceScoreFactor = {
+  key: AudienceScoreFactorKey;
+  label: string;
+  value: number;
+  maxValue: number;
+  weight: number;
+  weightedValue: number;
+  detail: string;
+  sentiment: "positive" | "neutral" | "negative";
+};
+
+export type AudienceScoreInput = {
+  login: string;
+  followers: number;
+  following?: number;
+  publicRepos: number;
+  publicGists?: number;
+  company: string | null;
+  bio: string | null;
+  location: string | null;
+  blog?: string | null;
+  twitterUsername?: string | null;
+  accountCreatedAt?: string | null;
+  accountUpdatedAt?: string | null;
+  starredAt: string | null;
+  targetLanguage?: string | null;
+  targetTopics?: string[];
+  orgs?: AudienceOrgSignal[];
+  repos?: AudienceRepoSignal[];
+};
+
+export type AudienceScore = {
+  score: number;
+  tier: AudienceScoreTier;
+  reasons: string[];
+  dimensions: AudienceScoreDimensions;
+  factors: AudienceScoreFactor[];
+};
+
+const roleKeywords = [
+  "cto",
+  "chief",
+  "lead",
+  "senior",
+  "sr",
+  "director",
+  "head",
+  "manager",
+  "architect",
+  "principal",
+  "founder",
+  "ceo",
+  "vp",
+  "engineering",
+  "developer",
+  "software",
+  "programmer",
+  "devops",
+  "sre",
+  "infrastructure",
+  "cloud",
+  "machine learning",
+  "ml",
+  "ai",
+  "data scientist",
+  "analytics",
+];
+
+const knownCompanies = [
+  "google",
+  "microsoft",
+  "amazon",
+  "apple",
+  "meta",
+  "netflix",
+  "uber",
+  "airbnb",
+  "github",
+  "openai",
+  "anthropic",
+];
+
+const notableOrgKeywords = [
+  "apache",
+  "cloudflare",
+  "cncf",
+  "docker",
+  "electron",
+  "github",
+  "gitlab",
+  "google",
+  "kubernetes",
+  "linux",
+  "meta",
+  "microsoft",
+  "mozilla",
+  "nodejs",
+  "openai",
+  "rust-lang",
+  "vercel",
+];
+
+export function isLikelyBot(login: string): boolean {
+  const normalized = login.toLowerCase();
+  return (
+    normalized.endsWith("bot") ||
+    normalized.endsWith("-bot") ||
+    normalized.endsWith("[bot]") ||
+    normalized.includes("bot-") ||
+    normalized.startsWith("github-actions") ||
+    normalized.startsWith("dependabot") ||
+    normalized.startsWith("renovate")
+  );
+}
+
+function usefulText(value: string | null | undefined): string {
+  const normalized = (value ?? "").trim();
+  return normalized && !["none", "n/a", "-"].includes(normalized.toLowerCase()) ? normalized : "";
+}
+
+function daysSince(value: string | null | undefined): number | null {
+  if (!value) return null;
+  const time = Date.parse(value);
+  if (!Number.isFinite(time)) return null;
+  return Math.max(0, Math.floor((Date.now() - time) / 86400000));
+}
+
+function addReason(reasons: string[], reason: string): void {
+  if (reasons.length < 10 && !reasons.includes(reason)) {
+    reasons.push(reason);
+  }
+}
+
+function clampScore(value: number): number {
+  return Math.max(0, Math.min(100, Math.round(value)));
+}
+
+function textMatchesAny(value: string, keywords: string[]): string | null {
+  const normalized = value.toLowerCase();
+  return keywords.find((keyword) => normalized.includes(keyword)) ?? null;
+}
+
+function normalizedTopicSet(topics: string[] | undefined): Set<string> {
+  return new Set((topics ?? []).map((topic) => topic.toLowerCase()));
+}
+
+function factor(
+  key: AudienceScoreFactorKey,
+  label: string,
+  value: number,
+  maxValue: number,
+  weight: number,
+  detail: string,
+  sentiment: AudienceScoreFactor["sentiment"] = "positive",
+): AudienceScoreFactor {
+  const normalizedMax = Math.max(1, maxValue);
+  return {
+    key,
+    label,
+    value: clampScore(value),
+    maxValue: normalizedMax,
+    weight,
+    weightedValue: Math.round(clampScore(value) * weight * 100) / 100,
+    detail,
+    sentiment,
+  };
+}
+
+export function calculateAudienceScore(input: AudienceScoreInput): AudienceScore {
+  if (isLikelyBot(input.login)) {
+    return {
+      score: 0,
+      tier: "bot",
+      reasons: ["automation account"],
+      dimensions: {
+        trust: 0,
+        influence: 0,
+        builder: 0,
+        recency: 0,
+        risk: 0,
+      },
+      factors: [
+        factor(
+          "risk",
+          "account safety",
+          0,
+          100,
+          0.14,
+          "login pattern matches an automation account",
+          "negative",
+        ),
+      ],
+    };
+  }
+
+  const reasons: string[] = [];
+  const profileFields = [
+    usefulText(input.company),
+    usefulText(input.bio),
+    usefulText(input.location),
+    usefulText(input.blog),
+    usefulText(input.twitterUsername),
+  ].filter(Boolean).length;
+  const accountAge = daysSince(input.accountCreatedAt);
+  const orgs = input.orgs ?? [];
+  const repos = (input.repos ?? []).filter((repo) => !repo.fullName.includes("/."));
+  const totalRepoStars = repos.reduce((sum, repo) => sum + repo.stars, 0);
+  const totalRepoForks = repos.reduce((sum, repo) => sum + repo.forks, 0);
+  const latestRepoUpdatedAt = repos
+    .map((repo) => Date.parse(repo.pushedAt ?? repo.updatedAt ?? ""))
+    .filter(Number.isFinite)
+    .sort((a, b) => b - a)[0];
+  const latestRepoAgeDays = latestRepoUpdatedAt
+    ? Math.max(0, Math.floor((Date.now() - latestRepoUpdatedAt) / 86400000))
+    : null;
+  const targetLanguage = usefulText(input.targetLanguage).toLowerCase();
+  const targetTopics = normalizedTopicSet(input.targetTopics);
+  const languageMatches =
+    targetLanguage && repos.some((repo) => repo.language?.toLowerCase() === targetLanguage);
+  const topicMatches = repos.some((repo) =>
+    (repo.topics ?? []).some((topic) => targetTopics.has(topic.toLowerCase())),
+  );
+  const notableOrg = orgs.find((org) =>
+    textMatchesAny(`${org.login} ${org.description ?? ""}`, notableOrgKeywords),
+  );
+  const company = usefulText(input.company);
+  const knownCompany = knownCompanies.some((known) => company.toLowerCase().includes(known));
+
+  if (input.followers > 0) {
+    if (input.followers >= 1000) {
+      addReason(reasons, `${input.followers.toLocaleString("en")} followers`);
+    } else if (input.followers >= 100) {
+      addReason(reasons, "established GitHub audience");
+    }
+  }
+
+  if (input.publicRepos > 0) {
+    if (input.publicRepos >= 50) {
+      addReason(reasons, "deep public repo history");
+    } else if (input.publicRepos >= 10) {
+      addReason(reasons, "active public builder");
+    }
+  }
+
+  if (company) {
+    addReason(reasons, "public company signal");
+    if (knownCompany) {
+      addReason(reasons, "known tech company");
+    }
+  }
+
+  const bio = usefulText(input.bio).toLowerCase();
+  const roleMatch = roleKeywords.find((keyword) => bio.includes(keyword));
+  if (roleMatch) {
+    addReason(reasons, `bio mentions ${roleMatch}`);
+  } else if (bio.length > 20) {
+    addReason(reasons, "filled-out public profile");
+  }
+
+  const stargazerAgeDays = daysSince(input.starredAt);
+  if (stargazerAgeDays !== null) {
+    if (stargazerAgeDays <= 7) {
+      addReason(reasons, "starred this week");
+    } else if (stargazerAgeDays <= 30) {
+      addReason(reasons, "recent stargazer");
+    }
+  }
+
+  if (orgs.length > 0) {
+    addReason(
+      reasons,
+      `${orgs.length.toLocaleString("en")} public org${orgs.length === 1 ? "" : "s"}`,
+    );
+  }
+  if (notableOrg) {
+    addReason(reasons, `notable org: ${notableOrg.login}`);
+  }
+  if (totalRepoStars >= 100) {
+    addReason(reasons, `${totalRepoStars.toLocaleString("en")} stars across recent repos`);
+  } else if (repos.some((repo) => repo.stars >= 25)) {
+    addReason(reasons, "starred public project");
+  }
+  if (languageMatches) {
+    addReason(reasons, `${input.targetLanguage} repo history`);
+  }
+  if (topicMatches) {
+    addReason(reasons, "repo topics overlap");
+  }
+
+  const ageTrust = accountAge === null ? 0 : accountAge >= 730 ? 24 : accountAge >= 180 ? 14 : 4;
+  const profileTrust = Math.min(profileFields * 7, 28) + (company ? 10 : 0);
+  const orgTrust = Math.min(orgs.length * 6, 18) + (notableOrg ? 16 : 0);
+  const followerReach = Math.min(Math.log10(input.followers + 1) * 24, 62);
+  const repoReach = Math.min(Math.log10(totalRepoStars + 1) * 12, 28);
+  const followingReach = Math.min(Math.log10((input.following ?? 0) + 1) * 2, 10);
+  const repoBuilder =
+    Math.min(Math.log10(input.publicRepos + 1) * 18, 42) +
+    Math.min(Math.log10(totalRepoStars + totalRepoForks + 1) * 14, 34);
+  const gistBuilder = Math.min((input.publicGists ?? 0) * 1.5, 8);
+  const activityBuilder = latestRepoAgeDays !== null && latestRepoAgeDays <= 45 ? 12 : 0;
+  const languageBuilder = languageMatches ? 8 : 0;
+  const influence = clampScore(followerReach + repoReach + followingReach);
+  const builder = clampScore(repoBuilder + gistBuilder + activityBuilder + languageBuilder);
+  const trust = clampScore(ageTrust + profileTrust + orgTrust);
+  const recency = clampScore(
+    stargazerAgeDays === null
+      ? 0
+      : stargazerAgeDays <= 7
+        ? 100
+        : stargazerAgeDays <= 30
+          ? 65
+          : stargazerAgeDays <= 90
+            ? 28
+            : 8,
+  );
+  const newAccountRisk = accountAge !== null && accountAge < 30 ? 24 : 0;
+  const emptyGraphRisk = input.followers < 3 && input.publicRepos < 2 ? 22 : 0;
+  const blankProfileRisk = profileFields === 0 ? 18 : 0;
+  const followSpamRisk = input.followers === 0 && (input.following ?? 0) > 100 ? 18 : 0;
+  const riskPenalty = clampScore(
+    newAccountRisk + emptyGraphRisk + blankProfileRisk + followSpamRisk,
+  );
+  const safety = clampScore(100 - riskPenalty);
+  const safetyDetail =
+    [
+      newAccountRisk ? "new account" : "",
+      emptyGraphRisk ? "thin public graph" : "",
+      blankProfileRisk ? "blank profile" : "",
+      followSpamRisk ? "high following with no followers" : "",
+    ]
+      .filter(Boolean)
+      .join(", ") || "no obvious public-account risk";
+  const dimensions = { trust, influence, builder, recency, risk: safety };
+  const recencyWeight = stargazerAgeDays === null ? 0 : 0.05;
+  const scoreWeight = 0.26 + 0.27 + 0.28 + 0.14 + recencyWeight;
+  const displayWeight = (weight: number) => weight / scoreWeight;
+  const factors: AudienceScoreFactor[] = [
+    factor(
+      "age",
+      "account age",
+      ageTrust,
+      24,
+      displayWeight(0.28),
+      accountAge === null
+        ? "GitHub account age unavailable"
+        : `${accountAge.toLocaleString("en")} days on GitHub`,
+      ageTrust > 0 ? "positive" : "neutral",
+    ),
+    factor(
+      "profile",
+      "profile completeness",
+      profileTrust,
+      38,
+      displayWeight(0.28),
+      `${profileFields}/5 profile fields${company ? ", company present" : ""}`,
+      profileTrust > 0 ? "positive" : "neutral",
+    ),
+    factor(
+      "orgs",
+      "org proof",
+      orgTrust,
+      34,
+      displayWeight(0.28),
+      notableOrg
+        ? `${orgs.length.toLocaleString("en")} public orgs, notable ${notableOrg.login}`
+        : `${orgs.length.toLocaleString("en")} public orgs`,
+      orgTrust > 0 ? "positive" : "neutral",
+    ),
+    factor(
+      "reach",
+      "public reach",
+      influence,
+      100,
+      displayWeight(0.26),
+      `${input.followers.toLocaleString("en")} followers, ${totalRepoStars.toLocaleString("en")} recent repo stars`,
+      influence > 0 ? "positive" : "neutral",
+    ),
+    factor(
+      "builder",
+      "builder history",
+      builder,
+      100,
+      displayWeight(0.27),
+      `${input.publicRepos.toLocaleString("en")} public repos, ${repos.length.toLocaleString("en")} recent repos scanned`,
+      builder > 0 ? "positive" : "neutral",
+    ),
+    factor(
+      "recency",
+      "stargazer recency",
+      recency,
+      100,
+      displayWeight(recencyWeight),
+      stargazerAgeDays === null
+        ? "not scored for profile-only trust pages"
+        : `${stargazerAgeDays.toLocaleString("en")} days since starring`,
+      recency > 0 ? "positive" : "neutral",
+    ),
+    factor(
+      "risk",
+      "account safety",
+      safety,
+      100,
+      displayWeight(0.14),
+      safetyDetail,
+      safety >= 85 ? "positive" : safety >= 70 ? "neutral" : "negative",
+    ),
+  ];
+  const score = clampScore(
+    (influence * 0.26 + builder * 0.27 + trust * 0.28 + safety * 0.14 + recency * recencyWeight) /
+      scoreWeight,
+  );
+  return {
+    score,
+    tier: score >= 70 ? "high" : score >= 40 ? "medium" : "low",
+    reasons: reasons.length > 0 ? reasons : ["public profile signal is light"],
+    dimensions,
+    factors,
+  };
+}

--- a/scripts/lib/dashboard.test.ts
+++ b/scripts/lib/dashboard.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import { generateKeyPairSync } from "node:crypto";
 import test from "node:test";
 
+import { calculateAudienceScore, isLikelyBot } from "./audience.js";
 import {
   buildDashboard,
   dashboardCacheKey,
@@ -18,6 +19,7 @@ import {
   ownerDashboardPath,
   optionsFromSearch,
   ownerFromPath,
+  fallbackApiOrigin,
   repoDetailPath,
   repoFromPath,
   workerApiOrigin,
@@ -36,8 +38,11 @@ import type {
   DashboardPayload,
   OwnerActivityPayload,
   Project,
+  AudienceRange,
+  RepoAudiencePayload,
   RepoDetailActivityPayload,
   RepoDetailPayload,
+  TrustProfilePayload,
 } from "../../src/types.js";
 import worker, { DashboardBuildLock } from "../../worker/index.js";
 
@@ -224,6 +229,14 @@ test("owner route parsing keeps root hot board and owners API-backed", () => {
     `${workersDevApiOrigin}/api/dashboard?owners=openclaw`,
   );
   assert.equal(
+    fallbackApiOrigin({ protocol: "http:", hostname: "127.0.0.1", port: "5174" }),
+    "http://127.0.0.1:8787",
+  );
+  assert.equal(
+    fallbackApiOrigin({ protocol: "http:", hostname: "localhost", port: "8787" }),
+    workersDevApiOrigin,
+  );
+  assert.equal(
     dashboardRoute(
       "/openclaw",
       "?q=codex&lang=Swift&filter=attention&sort=issues&dir=desc&dev=true",
@@ -376,6 +389,130 @@ test("repository detail hides unavailable code churn", () => {
     }),
     true,
   );
+});
+
+test("audience scoring uses only public profile and stargazer signals", () => {
+  assert.equal(isLikelyBot("dependabot"), true);
+  const bot = calculateAudienceScore({
+    login: "github-actions[bot]",
+    followers: 100000,
+    following: 0,
+    publicRepos: 100,
+    publicGists: 0,
+    company: "GitHub",
+    bio: "Automation",
+    location: "CI",
+    blog: null,
+    twitterUsername: null,
+    accountCreatedAt: "2018-01-01T00:00:00Z",
+    accountUpdatedAt: "2026-05-18T00:00:00Z",
+    starredAt: "2026-05-18T00:00:00Z",
+  });
+  assert.equal(bot.score, 0);
+  assert.equal(bot.tier, "bot");
+  assert.deepEqual(bot.reasons, ["automation account"]);
+  assert.deepEqual(bot.dimensions, {
+    trust: 0,
+    influence: 0,
+    builder: 0,
+    recency: 0,
+    risk: 0,
+  });
+  assert.equal(bot.factors[0]?.key, "risk");
+  assert.equal(bot.factors[0]?.label, "account safety");
+  assert.equal(bot.factors[0]?.sentiment, "negative");
+
+  const high = calculateAudienceScore({
+    login: "human",
+    followers: 2500,
+    following: 100,
+    publicRepos: 90,
+    publicGists: 4,
+    company: "GitHub",
+    bio: "Principal software engineer working on developer tools",
+    location: "San Francisco",
+    blog: "https://human.dev",
+    twitterUsername: "human",
+    accountCreatedAt: "2015-01-01T00:00:00Z",
+    starredAt: new Date().toISOString(),
+    targetLanguage: "TypeScript",
+    orgs: [{ login: "github", description: "How people build software" }],
+    repos: [
+      {
+        fullName: "human/toolkit",
+        description: "Developer tools",
+        url: "https://github.com/human/toolkit",
+        language: "TypeScript",
+        stars: 450,
+        forks: 20,
+        updatedAt: new Date().toISOString(),
+        pushedAt: new Date().toISOString(),
+        topics: ["developer-tools"],
+      },
+    ],
+  });
+  assert.equal(high.tier, "high");
+  assert.ok(high.score >= 70);
+  assert.ok(high.reasons.includes("known tech company"));
+  assert.ok(high.reasons.includes("notable org: github"));
+  assert.ok(high.dimensions.trust >= 80);
+  assert.equal(high.dimensions.risk, 100);
+  assert.equal(high.factors.find((factor) => factor.key === "age")?.label, "account age");
+  assert.deepEqual(
+    high.factors.map((factor) => factor.key),
+    ["age", "profile", "orgs", "reach", "builder", "recency", "risk"],
+  );
+  assert.ok((high.factors.find((factor) => factor.key === "builder")?.weightedValue ?? 0) > 0);
+  const profileOnly = calculateAudienceScore({
+    login: "human",
+    followers: 2500,
+    following: 100,
+    publicRepos: 90,
+    publicGists: 4,
+    company: "GitHub",
+    bio: "Principal software engineer working on developer tools",
+    location: "San Francisco",
+    blog: "https://human.dev",
+    twitterUsername: "human",
+    accountCreatedAt: "2015-01-01T00:00:00Z",
+    starredAt: null,
+    targetLanguage: "TypeScript",
+    orgs: [{ login: "github", description: "How people build software" }],
+    repos: [
+      {
+        fullName: "human/toolkit",
+        description: "Developer tools",
+        url: "https://github.com/human/toolkit",
+        language: "TypeScript",
+        stars: 450,
+        forks: 20,
+        updatedAt: new Date().toISOString(),
+        pushedAt: new Date().toISOString(),
+        topics: ["developer-tools"],
+      },
+    ],
+  });
+  assert.equal(profileOnly.factors.find((factor) => factor.key === "recency")?.weight, 0);
+  assert.equal(profileOnly.tier, "high");
+  assert.equal(
+    Math.round(profileOnly.factors.reduce((sum, factor) => sum + factor.weightedValue, 0)),
+    profileOnly.score,
+  );
+
+  const low = calculateAudienceScore({
+    login: "quiet-user",
+    followers: 2,
+    following: 0,
+    publicRepos: 1,
+    publicGists: 0,
+    company: null,
+    bio: null,
+    location: null,
+    starredAt: null,
+  });
+  assert.equal(low.tier, "low");
+  assert.ok(low.score < 40);
+  assert.equal(low.factors.find((factor) => factor.key === "risk")?.sentiment, "negative");
 });
 
 test("need attention explains release debt, stale releases, CI, and open work", () => {
@@ -648,6 +785,58 @@ test("worker embeds cached public dashboard data in the app shell", async () => 
   assert.match(html, /"route":"dashboard"/);
   assert.match(html, /acme\\u002freleasebar|acme\/releasebar/);
   assert.ok(html.indexOf('id="releasebar-initial-data"') < html.indexOf('<script type="module"'));
+});
+
+test("worker embeds cached metadata-only owner dashboard data in the app shell", async () => {
+  const payload = testDashboard("owner", [
+    testProject({
+      owner: "owner",
+      name: "repo",
+      version: "repo search",
+      releaseDate: null,
+      commitsSinceRelease: null,
+      compareUrl: null,
+    }),
+  ]);
+  payload.options = { ...payload.options!, includeUnreleased: true };
+  payload.cache = {
+    ...payload.cache!,
+    message: "release scan skipped until GitHub App quota is available",
+  };
+  const key = dashboardCacheKey({
+    owner: "owner",
+    includeUnreleased: true,
+    includeReleaseData: false,
+    schemaVersion: 5,
+  });
+  const response = await worker.fetch(
+    new Request("https://release.bar/owner", { headers: { cookie: "rd_session=bogus" } }),
+    {
+      ASSETS: {
+        fetch: async (request: Request) => {
+          assert.equal(new URL(request.url).pathname, "/index.html");
+          return new Response(
+            '<title>ReleaseBar</title><script type="module" src="/assets/index.js"></script>',
+            { headers: { "content-type": "text/html" } },
+          );
+        },
+      },
+      DASHBOARD_CACHE: kvStore({
+        [key]: JSON.stringify(payload),
+      }),
+      GITHUB_APP_ID: "123",
+      GITHUB_APP_PRIVATE_KEY: "not-a-private-key",
+    },
+    { waitUntil: () => undefined },
+  );
+
+  const html = await response.text();
+  assert.equal(response.status, 200);
+  assert.equal(response.headers.get("cache-control"), "private, no-store");
+  assert.equal(response.headers.get("vary"), "cookie");
+  assert.match(html, /id="releasebar-initial-data"/);
+  assert.match(html, /owner\\u002frepo|owner\/repo/);
+  assert.match(html, /release scan skipped/);
 });
 
 test("worker embeds cached language-filtered discover data in the app shell", async () => {
@@ -1305,7 +1494,16 @@ test("worker builds cached repository detail with releases and stats", async () 
     throw new Error(`unexpected fetch ${url.pathname}`);
   };
   const env = {
-    DASHBOARD_CACHE: kvStore(),
+    DASHBOARD_CACHE: kvStore({
+      "trust-profile:v4:octo": JSON.stringify({
+        login: "octo",
+        profileKind: "user_trust",
+        scoreLabel: "trust score",
+        score: 73,
+        tier: "high",
+        generatedAt: "2026-05-16T12:00:00Z",
+      }),
+    }),
     GITHUB_TOKEN: "shared-token",
   };
   try {
@@ -1325,6 +1523,8 @@ test("worker builds cached repository detail with releases and stats", async () 
     assert.equal(body.project.ciWorkflow, "Lint");
     assert.equal(body.releases.length, 2);
     assert.equal(body.contributors[0]?.login, "octo");
+    assert.equal(body.contributors[0]?.trustScore, 73);
+    assert.equal(body.contributors[0]?.trustTier, "high");
     assert.equal(body.commitActivity[0]?.total, 7);
     assert.equal(body.codeFrequency[0]?.additions, 120);
     assert.equal(body.codeFrequency[0]?.deletions, 20);
@@ -1337,13 +1537,1089 @@ test("worker builds cached repository detail with releases and stats", async () 
       ["TypeScript", "CSS"],
     );
 
+    await env.DASHBOARD_CACHE.put(
+      "trust-profile:v4:octo",
+      JSON.stringify({
+        login: "octo",
+        profileKind: "user_trust",
+        scoreLabel: "trust score",
+        score: 62,
+        tier: "medium",
+        generatedAt: "2026-05-16T12:05:00Z",
+      }),
+    );
     const cached = await worker.fetch(
       new Request("https://release.bar/api/repos/acme/releasebar"),
       env,
       { waitUntil: () => undefined },
     );
     assert.equal(cached.status, 200);
+    const cachedBody = (await cached.json()) as RepoDetailPayload;
+    assert.equal(cachedBody.contributors[0]?.trustScore, 62);
+    assert.equal(cachedBody.contributors[0]?.trustTier, "medium");
     assert.equal(calls, 14);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("worker builds cached repository audience from public stargazers", async () => {
+  const originalFetch = globalThis.fetch;
+  let calls = 0;
+  globalThis.fetch = async (input, init) => {
+    calls += 1;
+    const url = new URL(String(input));
+    const path = url.pathname;
+    if (path === "/repos/acme/releasebar") {
+      return Response.json({
+        owner: { login: "acme" },
+        name: "releasebar",
+        full_name: "acme/releasebar",
+        private: false,
+        fork: false,
+        archived: false,
+        html_url: "https://github.com/acme/releasebar",
+        description: "Release dashboard",
+        default_branch: "main",
+        language: "TypeScript",
+        topics: [],
+        stargazers_count: 1234,
+        forks_count: 45,
+        open_issues_count: 9,
+        pushed_at: "2026-05-16T12:00:00Z",
+        updated_at: "2026-05-16T12:00:00Z",
+      });
+    }
+    if (path === "/graphql") {
+      const body = JSON.parse(String(init?.body ?? "{}")) as {
+        variables?: { owner?: string; name?: string; first?: number };
+      };
+      assert.equal(body.variables?.owner, "acme");
+      assert.equal(body.variables?.name, "releasebar");
+      assert.equal(body.variables?.first, 30);
+      return Response.json({
+        data: {
+          repository: {
+            stargazers: {
+              edges: [
+                {
+                  starredAt: new Date().toISOString(),
+                  node: {
+                    login: "principal",
+                    avatarUrl: "https://avatars.githubusercontent.com/u/10",
+                    url: "https://github.com/principal",
+                  },
+                },
+                {
+                  starredAt: new Date().toISOString(),
+                  node: {
+                    login: "quiet",
+                    avatarUrl: "https://avatars.githubusercontent.com/u/11",
+                    url: "https://github.com/quiet",
+                  },
+                },
+                {
+                  starredAt: new Date().toISOString(),
+                  node: {
+                    login: "renovate-bot",
+                    avatarUrl: "https://avatars.githubusercontent.com/u/12",
+                    url: "https://github.com/renovate-bot",
+                  },
+                },
+              ],
+            },
+          },
+        },
+      });
+    }
+    if (path === "/repos/acme/releasebar/stargazers") {
+      const headers = init?.headers as Record<string, string> | undefined;
+      assert.equal(headers instanceof Headers, false);
+      assert.match(String(headers?.accept), /star\+json/);
+      if (url.searchParams.get("page") !== "3") {
+        return Response.json(
+          [
+            {
+              starred_at: "2020-01-01T00:00:00Z",
+              user: {
+                login: "old",
+                avatar_url: "https://avatars.githubusercontent.com/u/9",
+                html_url: "https://github.com/old",
+              },
+            },
+          ],
+          {
+            headers: {
+              link: '<https://api.github.com/repos/acme/releasebar/stargazers?per_page=30&page=3>; rel="last"',
+            },
+          },
+        );
+      }
+      return Response.json([
+        {
+          starred_at: new Date().toISOString(),
+          user: {
+            login: "principal",
+            avatar_url: "https://avatars.githubusercontent.com/u/10",
+            html_url: "https://github.com/principal",
+          },
+        },
+        {
+          starred_at: new Date().toISOString(),
+          user: {
+            login: "quiet",
+            avatar_url: "https://avatars.githubusercontent.com/u/11",
+            html_url: "https://github.com/quiet",
+          },
+        },
+        {
+          starred_at: new Date().toISOString(),
+          user: {
+            login: "renovate-bot",
+            avatar_url: "https://avatars.githubusercontent.com/u/12",
+            html_url: "https://github.com/renovate-bot",
+          },
+        },
+      ]);
+    }
+    if (path === "/users/principal") {
+      return Response.json({
+        login: "principal",
+        avatar_url: "https://avatars.githubusercontent.com/u/10",
+        html_url: "https://github.com/principal",
+        type: "User",
+        name: "Principal Engineer",
+        company: "GitHub",
+        bio: "Principal software engineer building developer tools",
+        location: "San Francisco",
+        blog: "https://principal.dev",
+        twitter_username: "principal",
+        followers: 2500,
+        following: 120,
+        public_repos: 80,
+        public_gists: 9,
+        created_at: "2012-01-01T00:00:00Z",
+        updated_at: "2026-05-16T12:00:00Z",
+      });
+    }
+    if (path === "/users/principal/orgs") {
+      return Response.json([
+        {
+          login: "github",
+          avatar_url: "https://avatars.githubusercontent.com/u/9919",
+          description: "How people build software",
+        },
+        {
+          login: "acme",
+          avatar_url: "https://avatars.githubusercontent.com/u/20",
+          description: "Developer tools",
+        },
+      ]);
+    }
+    if (path === "/users/principal/repos") {
+      return Response.json([
+        {
+          full_name: "principal/release-tools",
+          html_url: "https://github.com/principal/release-tools",
+          description: "Release tooling",
+          language: "TypeScript",
+          stargazers_count: 350,
+          forks_count: 24,
+          fork: false,
+          archived: false,
+          topics: ["release", "developer-tools"],
+          pushed_at: new Date().toISOString(),
+          updated_at: new Date().toISOString(),
+        },
+      ]);
+    }
+    if (path === "/users/quiet") {
+      return Response.json({
+        login: "quiet",
+        avatar_url: "https://avatars.githubusercontent.com/u/11",
+        html_url: "https://github.com/quiet",
+        type: "User",
+        name: null,
+        company: null,
+        bio: null,
+        location: null,
+        blog: null,
+        twitter_username: null,
+        followers: 2,
+        following: 0,
+        public_repos: 1,
+        public_gists: 0,
+        created_at: "2026-05-01T00:00:00Z",
+        updated_at: "2026-05-16T12:00:00Z",
+      });
+    }
+    if (path === "/users/quiet/orgs") {
+      return Response.json([]);
+    }
+    if (path === "/users/quiet/repos") {
+      return Response.json([]);
+    }
+    if (path === "/users/renovate-bot") {
+      return Response.json({
+        login: "renovate-bot",
+        avatar_url: "https://avatars.githubusercontent.com/u/12",
+        html_url: "https://github.com/renovate-bot",
+        type: "Bot",
+        name: null,
+        company: null,
+        bio: null,
+        location: null,
+        blog: null,
+        twitter_username: null,
+        followers: 1000,
+        following: 0,
+        public_repos: 100,
+        public_gists: 0,
+        created_at: "2015-01-01T00:00:00Z",
+        updated_at: "2026-05-16T12:00:00Z",
+      });
+    }
+    throw new Error(`unexpected fetch ${url.pathname}`);
+  };
+  const env = {
+    DASHBOARD_CACHE: kvStore({
+      "trust-profile:v4:principal": JSON.stringify({
+        login: "principal",
+        profileKind: "user_trust",
+        scoreLabel: "trust score",
+        score: 88,
+        tier: "high",
+        generatedAt: "2026-05-16T12:00:00Z",
+      }),
+    }),
+    GITHUB_TOKEN: "shared-token",
+  };
+  try {
+    const response = await worker.fetch(
+      new Request("https://release.bar/api/repos/acme/releasebar/audience"),
+      env,
+      { waitUntil: () => undefined },
+    );
+    assert.equal(response.status, 200);
+    const body = (await response.json()) as RepoAudiencePayload;
+    assert.equal(body.fullName, "acme/releasebar");
+    assert.equal(body.range, "month");
+    assert.equal(body.users[0]?.login, "principal");
+    assert.equal(body.users[0]?.tier, "high");
+    assert.equal(body.users[0]?.trustScore, 88);
+    assert.equal(body.users[0]?.trustTier, "high");
+    assert.ok((body.users[0]?.dimensions.trust ?? 0) >= 80);
+    assert.equal(body.users[0]?.orgs[0]?.login, "github");
+    assert.equal(body.users[0]?.topRepositories[0]?.fullName, "principal/release-tools");
+    assert.match(body.users[0]?.reasons.join(" ") ?? "", /notable org: github/);
+    assert.equal(body.totals.stargazers, 1234);
+    assert.equal(body.totals.highSignal, 1);
+    assert.equal(body.totals.bots, 1);
+    assert.equal(body.totals.highSignalPercent, 33);
+    assert.equal(body.totals.mediumSignalPercent, 0);
+    assert.equal(body.totals.lowSignalPercent, 33);
+    assert.equal(body.totals.botPercent, 33);
+    assert.equal(body.cache.quota?.source, "shared");
+
+    const cached = await worker.fetch(
+      new Request("https://release.bar/api/repos/acme/releasebar/audience"),
+      env,
+      { waitUntil: () => undefined },
+    );
+    assert.equal(cached.status, 200);
+    assert.equal(calls, 9);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("worker REST stargazer fallback samples newest stargazers", async () => {
+  const originalFetch = globalThis.fetch;
+  const stargazerPages: string[] = [];
+  globalThis.fetch = async (input, init) => {
+    const url = new URL(String(input));
+    const path = url.pathname;
+    if (path === "/repos/acme/restbar") {
+      return Response.json({
+        owner: { login: "acme" },
+        name: "restbar",
+        full_name: "acme/restbar",
+        private: false,
+        fork: false,
+        archived: false,
+        html_url: "https://github.com/acme/restbar",
+        description: "REST fallback",
+        default_branch: "main",
+        language: "TypeScript",
+        topics: [],
+        stargazers_count: 31,
+        forks_count: 1,
+        open_issues_count: 0,
+        pushed_at: "2026-05-16T12:00:00Z",
+        updated_at: "2026-05-16T12:00:00Z",
+      });
+    }
+    if (path === "/repos/acme/restbar/stargazers") {
+      const headers = init?.headers as Record<string, string> | undefined;
+      assert.match(String(headers?.accept), /star\+json/);
+      stargazerPages.push(url.searchParams.get("page") ?? "first");
+      if (url.searchParams.get("page") !== "2") {
+        return Response.json(
+          [
+            {
+              starred_at: new Date().toISOString(),
+              user: {
+                login: "previous",
+                avatar_url: "https://avatars.githubusercontent.com/u/10",
+                html_url: "https://github.com/previous",
+              },
+            },
+          ],
+          !url.searchParams.has("page")
+            ? {
+                headers: {
+                  link: '<https://api.github.com/repos/acme/restbar/stargazers?per_page=30&page=2>; rel="last"',
+                },
+              }
+            : undefined,
+        );
+      }
+      return Response.json([
+        {
+          starred_at: new Date().toISOString(),
+          user: {
+            login: "newest",
+            avatar_url: "https://avatars.githubusercontent.com/u/11",
+            html_url: "https://github.com/newest",
+          },
+        },
+      ]);
+    }
+    const user = path.match(/^\/users\/([^/]+)$/)?.[1];
+    if (user === "previous" || user === "newest") {
+      return Response.json({
+        login: user,
+        avatar_url: `https://avatars.githubusercontent.com/u/${user === "previous" ? "10" : "11"}`,
+        html_url: `https://github.com/${user}`,
+        type: "User",
+        name: user,
+        company: null,
+        bio: null,
+        location: null,
+        blog: null,
+        twitter_username: null,
+        followers: user === "newest" ? 20 : 10,
+        following: 1,
+        public_repos: 2,
+        public_gists: 0,
+        created_at: "2020-01-01T00:00:00Z",
+        updated_at: "2026-05-16T12:00:00Z",
+      });
+    }
+    if (path === "/users/previous/orgs" || path === "/users/newest/orgs") {
+      return Response.json([]);
+    }
+    if (path === "/users/previous/repos" || path === "/users/newest/repos") {
+      return Response.json([]);
+    }
+    throw new Error(`unexpected fetch ${path}`);
+  };
+  try {
+    const response = await worker.fetch(
+      new Request("https://release.bar/api/repos/acme/restbar/audience"),
+      { DASHBOARD_CACHE: kvStore() },
+      { waitUntil: () => undefined },
+    );
+    assert.equal(response.status, 200);
+    const body = (await response.json()) as RepoAudiencePayload;
+    assert.deepEqual(stargazerPages, ["first", "2", "1"]);
+    assert.deepEqual(body.users.map((user) => user.login).sort(), ["newest", "previous"]);
+    assert.equal(body.totals.stargazers, 31);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("worker serves OpenAPI spec aliases for Swagger tooling", async () => {
+  const env = { DASHBOARD_CACHE: kvStore() };
+  for (const path of ["/openapi.json", "/api/openapi.json", "/api/swagger.json"]) {
+    const response = await worker.fetch(new Request(`https://release.bar${path}`), env, {
+      waitUntil: () => undefined,
+    });
+    assert.equal(response.status, 200);
+    const body = (await response.json()) as {
+      openapi?: string;
+      paths?: Record<string, unknown>;
+    };
+    assert.equal(body.openapi, "3.1.0");
+    assert.ok(body.paths?.["/api/users/{login}/trust"]);
+    assert.ok(body.paths?.["/api/repos/{owner}/{repo}/audience"]);
+  }
+});
+
+test("worker rejects malformed nested owner API paths", async () => {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (input) => {
+    throw new Error(`unexpected fetch ${String(input)}`);
+  };
+  try {
+    const response = await worker.fetch(
+      new Request("https://release.bar/api/openclaw/openclaw/audience"),
+      { DASHBOARD_CACHE: kvStore() },
+      { waitUntil: () => undefined },
+    );
+    assert.equal(response.status, 404);
+    const body = (await response.json()) as { error?: string };
+    assert.equal(body.error, "not found");
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("worker keeps unsynced app-configured audience GETs off shared quota", async () => {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (input) => {
+    throw new Error(`unexpected fetch ${String(input)}`);
+  };
+  try {
+    const response = await worker.fetch(
+      new Request("https://release.bar/api/repos/acme/releasebar/audience"),
+      {
+        DASHBOARD_CACHE: kvStore(),
+        GITHUB_APP_ID: "123",
+        GITHUB_APP_PRIVATE_KEY: "private-key",
+        GITHUB_TOKEN: "shared-token",
+      },
+      { waitUntil: () => undefined },
+    );
+    assert.equal(response.status, 403);
+    assert.equal(response.headers.get("cache-control"), "no-store");
+    const body = (await response.json()) as { error?: string };
+    assert.match(body.error ?? "", /GitHub App/);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("worker only backfills repository audience caches with GitHub App quota", async () => {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (input) => {
+    throw new Error(`unexpected fetch ${String(input)}`);
+  };
+  try {
+    const denied = await worker.fetch(
+      new Request("https://release.bar/api/repos/acme/releasebar/audience/backfill", {
+        method: "POST",
+      }),
+      { DASHBOARD_CACHE: kvStore(), GITHUB_TOKEN: "shared-token" },
+      { waitUntil: () => undefined },
+    );
+    assert.equal(denied.status, 403);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+
+  const { privateKey } = generateKeyPairSync("rsa", {
+    modulusLength: 2048,
+    privateKeyEncoding: { type: "pkcs1", format: "pem" },
+    publicKeyEncoding: { type: "spki", format: "pem" },
+  });
+  const sessionId = "audience-backfill";
+  const exp = Math.floor(Date.now() / 1000) + 600;
+  const authCookie = await signedJson("test-secret", { id: sessionId, exp });
+  const cache = kvStore({
+    [`auth:session:${sessionId}`]: JSON.stringify({
+      user: {
+        id: 1,
+        login: "octocat",
+        name: null,
+        avatarUrl: "https://avatars.githubusercontent.com/u/1",
+        url: "https://github.com/octocat",
+      },
+      accessToken: "user-token",
+      iat: exp - 600,
+      exp,
+    }),
+  });
+  const env = {
+    AUTH_COOKIE_SECRET: "test-secret",
+    DASHBOARD_CACHE: cache,
+    GITHUB_APP_CLIENT_ID: "Iv123",
+    GITHUB_APP_CLIENT_SECRET: "client-secret",
+    GITHUB_APP_ID: "123",
+    GITHUB_APP_PRIVATE_KEY: privateKey,
+    GITHUB_APP_SLUG: "releasebar-app",
+  };
+  let appCalls = 0;
+  globalThis.fetch = async (input, init) => {
+    const url = new URL(String(input));
+    const path = url.pathname;
+    const authorization = new Headers(init?.headers).get("authorization");
+    if (path === "/user/installations") {
+      assert.equal(authorization, "Bearer user-token");
+      return Response.json({
+        installations: [
+          {
+            id: 1,
+            account: {
+              login: "acme",
+              type: "Organization",
+              avatar_url: "https://avatars.githubusercontent.com/u/2",
+              html_url: "https://github.com/acme",
+            },
+            html_url: "https://github.com/organizations/acme/settings/installations/1",
+            repository_selection: "all",
+            target_type: "Organization",
+          },
+        ],
+      });
+    }
+    if (path === "/app/installations/1/access_tokens") {
+      assert.match(authorization ?? "", /^Bearer [^.]+\.[^.]+\.[^.]+$/);
+      return Response.json({ token: "installation-token" });
+    }
+    if (path === "/repos/acme/releasebar") {
+      appCalls += 1;
+      assert.equal(authorization, "Bearer installation-token");
+      return Response.json({
+        owner: { login: "acme" },
+        name: "releasebar",
+        full_name: "acme/releasebar",
+        private: false,
+        fork: false,
+        archived: false,
+        html_url: "https://github.com/acme/releasebar",
+        description: "Release dashboard",
+        default_branch: "main",
+        language: "TypeScript",
+        topics: ["developer-tools"],
+        stargazers_count: 1234,
+        forks_count: 45,
+        open_issues_count: 9,
+        pushed_at: "2026-05-16T12:00:00Z",
+        updated_at: "2026-05-16T12:00:00Z",
+      });
+    }
+    if (path === "/graphql") {
+      appCalls += 1;
+      assert.equal(authorization, "Bearer installation-token");
+      return Response.json({
+        data: {
+          repository: {
+            stargazers: {
+              edges: [
+                {
+                  starredAt: new Date().toISOString(),
+                  node: {
+                    login: "principal",
+                    avatarUrl: "https://avatars.githubusercontent.com/u/10",
+                    url: "https://github.com/principal",
+                  },
+                },
+              ],
+            },
+          },
+        },
+      });
+    }
+    if (path === "/users/principal") {
+      appCalls += 1;
+      assert.equal(authorization, "Bearer installation-token");
+      return Response.json({
+        login: "principal",
+        avatar_url: "https://avatars.githubusercontent.com/u/10",
+        html_url: "https://github.com/principal",
+        type: "User",
+        name: "Principal Engineer",
+        company: "GitHub",
+        bio: "Principal software engineer building developer tools",
+        location: "San Francisco",
+        blog: "https://principal.dev",
+        twitter_username: "principal",
+        followers: 2500,
+        following: 120,
+        public_repos: 80,
+        public_gists: 9,
+        created_at: "2012-01-01T00:00:00Z",
+        updated_at: "2026-05-16T12:00:00Z",
+      });
+    }
+    if (path === "/users/principal/orgs") {
+      appCalls += 1;
+      assert.equal(authorization, "Bearer installation-token");
+      return Response.json([
+        {
+          login: "github",
+          avatar_url: "https://avatars.githubusercontent.com/u/9919",
+          description: "How people build software",
+        },
+      ]);
+    }
+    if (path === "/users/principal/repos") {
+      appCalls += 1;
+      assert.equal(authorization, "Bearer installation-token");
+      return Response.json([
+        {
+          full_name: "principal/release-tools",
+          html_url: "https://github.com/principal/release-tools",
+          description: "Release tooling",
+          language: "TypeScript",
+          stargazers_count: 350,
+          forks_count: 24,
+          fork: false,
+          archived: false,
+          topics: ["release", "developer-tools"],
+          pushed_at: new Date().toISOString(),
+          updated_at: new Date().toISOString(),
+        },
+      ]);
+    }
+    throw new Error(`unexpected fetch ${path}`);
+  };
+  try {
+    const response = await worker.fetch(
+      new Request("https://release.bar/api/repos/acme/releasebar/audience/backfill", {
+        method: "POST",
+        headers: { cookie: `rd_session=${authCookie}` },
+      }),
+      env,
+      { waitUntil: () => undefined },
+    );
+    assert.equal(response.status, 200);
+    const body = (await response.json()) as {
+      fullName: string;
+      ranges: Array<{ range: AudienceRange; state: string; users: number }>;
+      quota: { source: string; account: string | null };
+    };
+    assert.equal(body.fullName, "acme/releasebar");
+    assert.deepEqual(
+      body.ranges.map((range) => `${range.range}:${range.state}:${range.users}`),
+      ["week:rebuilt:1", "month:rebuilt:1"],
+    );
+    assert.deepEqual(body.quota, { source: "app", account: "acme" });
+    assert.ok(appCalls > 0);
+
+    const cached = await worker.fetch(
+      new Request("https://release.bar/api/repos/acme/releasebar/audience?range=week"),
+      env,
+      { waitUntil: () => undefined },
+    );
+    const audience = (await cached.json()) as RepoAudiencePayload;
+    assert.equal(audience.cache.quota?.source, "app");
+    assert.equal(audience.users[0]?.factors.length, 7);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("worker builds bounded trust profiles for people pages", async () => {
+  const originalFetch = globalThis.fetch;
+  const paths: string[] = [];
+  globalThis.fetch = async (input) => {
+    const url = new URL(String(input));
+    paths.push(url.pathname);
+    if (url.pathname === "/users/principal") {
+      return Response.json({
+        login: "principal",
+        avatar_url: "https://avatars.githubusercontent.com/u/10",
+        html_url: "https://github.com/principal",
+        type: "User",
+        name: "Principal Engineer",
+        company: "GitHub",
+        bio: "Principal software engineer building developer tools",
+        location: "San Francisco",
+        blog: "https://principal.dev",
+        twitter_username: "principal",
+        followers: 2500,
+        following: 120,
+        public_repos: 80,
+        public_gists: 9,
+        created_at: "2012-01-01T00:00:00Z",
+        updated_at: "2026-05-16T12:00:00Z",
+      });
+    }
+    if (url.pathname === "/users/principal/orgs") {
+      return Response.json([
+        {
+          login: "github",
+          avatar_url: "https://avatars.githubusercontent.com/u/9919",
+          description: "How people build software",
+        },
+      ]);
+    }
+    if (url.pathname === "/users/principal/repos") {
+      return Response.json([
+        {
+          full_name: "principal/release-tools",
+          html_url: "https://github.com/principal/release-tools",
+          description: "Release tooling",
+          language: "TypeScript",
+          stargazers_count: 120,
+          forks_count: 12,
+          fork: false,
+          archived: false,
+          topics: ["release", "developer-tools"],
+          pushed_at: new Date().toISOString(),
+          updated_at: new Date().toISOString(),
+        },
+        {
+          full_name: "principal/trust-map",
+          html_url: "https://github.com/principal/trust-map",
+          description: "Trust signals",
+          language: "TypeScript",
+          stargazers_count: 10,
+          forks_count: 2,
+          fork: false,
+          archived: false,
+          topics: ["trust", "developer-tools"],
+          pushed_at: "2026-01-01T00:00:00Z",
+          updated_at: "2026-01-01T00:00:00Z",
+        },
+      ]);
+    }
+    throw new Error(`unexpected fetch ${url.pathname}`);
+  };
+  const env = {
+    DASHBOARD_CACHE: kvStore(),
+    GITHUB_TOKEN: "shared-token",
+  };
+  try {
+    const response = await worker.fetch(
+      new Request("https://release.bar/api/users/principal/trust"),
+      env,
+      { waitUntil: () => undefined },
+    );
+    assert.equal(response.status, 200);
+    const body = (await response.json()) as TrustProfilePayload;
+    assert.deepEqual(paths, [
+      "/users/principal",
+      "/users/principal/orgs",
+      "/users/principal/repos",
+    ]);
+    assert.equal(body.login, "principal");
+    assert.equal(body.type, "user");
+    assert.equal(body.profileKind, "user_trust");
+    assert.equal(body.scoreLabel, "trust score");
+    assert.equal(body.tier, "high");
+    assert.ok((body.accountAgeDays ?? 0) > 3650);
+    assert.ok(body.dimensions.trust >= 80);
+    assert.equal(body.stats.totalStars, 130);
+    assert.equal(body.stats.activeRepositories, 2);
+    assert.equal(body.stats.languages[0]?.name, "typescript");
+    assert.equal(body.stats.topics[0]?.name, "developer-tools");
+    assert.equal(body.orgs[0]?.login, "github");
+    assert.equal(body.topRepositories[0]?.fullName, "principal/release-tools");
+    assert.equal(body.factors.find((factor) => factor.key === "age")?.label, "account age");
+    assert.match(
+      body.factors.find((factor) => factor.key === "builder")?.detail ?? "",
+      /recent repos scanned/,
+    );
+    assert.match(body.reasons.join(" "), /notable org: github/);
+
+    const cached = await worker.fetch(
+      new Request("https://release.bar/api/users/principal/trust"),
+      env,
+      { waitUntil: () => undefined },
+    );
+    assert.equal(cached.status, 200);
+    assert.deepEqual(paths, [
+      "/users/principal",
+      "/users/principal/orgs",
+      "/users/principal/repos",
+    ]);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("worker uses registered app quota for anonymous trust profiles", async () => {
+  const cache = kvStore({
+    "auth:installation:v1:principal": JSON.stringify({
+      id: 42,
+      accountLogin: "principal",
+      accountType: "user",
+      accountUrl: "https://github.com/principal",
+      avatarUrl: "https://avatars.githubusercontent.com/u/10",
+      repositorySelection: "all",
+      repositories: [],
+      updatedAt: new Date().toISOString(),
+    }),
+    "auth:installation-token:42": "installation-token",
+  });
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (input, init) => {
+    const url = new URL(String(input));
+    const authorization = new Headers(init?.headers).get("authorization");
+    assert.equal(authorization, "Bearer installation-token");
+    if (url.pathname === "/users/principal") {
+      return Response.json({
+        login: "principal",
+        avatar_url: "https://avatars.githubusercontent.com/u/10",
+        html_url: "https://github.com/principal",
+        type: "User",
+        name: "Principal Engineer",
+        company: "GitHub",
+        bio: "Principal software engineer building developer tools",
+        location: "San Francisco",
+        blog: "https://principal.dev",
+        twitter_username: "principal",
+        followers: 2500,
+        following: 120,
+        public_repos: 80,
+        public_gists: 9,
+        created_at: "2012-01-01T00:00:00Z",
+        updated_at: "2026-05-16T12:00:00Z",
+      });
+    }
+    if (url.pathname === "/users/principal/orgs") {
+      return Response.json([]);
+    }
+    if (url.pathname === "/users/principal/repos") {
+      return Response.json([]);
+    }
+    throw new Error(`unexpected fetch ${url.pathname}`);
+  };
+  try {
+    const response = await worker.fetch(
+      new Request("https://release.bar/api/users/principal/trust"),
+      {
+        DASHBOARD_CACHE: cache,
+        GITHUB_APP_ID: "123",
+        GITHUB_APP_PRIVATE_KEY: "unused",
+        GITHUB_TOKEN: "shared-token",
+      },
+      { waitUntil: () => undefined },
+    );
+    assert.equal(response.status, 200);
+    const body = (await response.json()) as TrustProfilePayload;
+    assert.equal(body.cache.quota?.source, "app");
+    assert.equal(body.cache.quota?.account, "principal");
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("worker returns org signal profiles for organization accounts", async () => {
+  const originalFetch = globalThis.fetch;
+  const paths: string[] = [];
+  globalThis.fetch = async (input) => {
+    const url = new URL(String(input));
+    paths.push(url.pathname);
+    if (url.pathname === "/users/openclaw") {
+      return Response.json({
+        login: "openclaw",
+        avatar_url: "https://avatars.githubusercontent.com/u/20",
+        html_url: "https://github.com/openclaw",
+        type: "Organization",
+        name: "OpenClaw",
+        company: null,
+        bio: "Open source agent tooling",
+        location: "Internet",
+        blog: "https://openclaw.dev",
+        twitter_username: null,
+        followers: 1200,
+        following: 0,
+        public_repos: 42,
+        public_gists: 0,
+        created_at: "2018-01-01T00:00:00Z",
+        updated_at: "2026-05-16T12:00:00Z",
+      });
+    }
+    if (url.pathname === "/orgs/openclaw/repos") {
+      assert.equal(url.searchParams.get("type"), "public");
+      return Response.json([
+        {
+          full_name: "openclaw/openclaw",
+          html_url: "https://github.com/openclaw/openclaw",
+          description: "Agent runtime",
+          language: "TypeScript",
+          stargazers_count: 900,
+          forks_count: 80,
+          private: false,
+          visibility: "public",
+          fork: false,
+          archived: false,
+          topics: ["agents", "developer-tools"],
+          pushed_at: new Date().toISOString(),
+          updated_at: new Date().toISOString(),
+        },
+        {
+          full_name: "openclaw/private-signals",
+          html_url: "https://github.com/openclaw/private-signals",
+          description: "Should never leak",
+          language: "TypeScript",
+          stargazers_count: 9999,
+          forks_count: 0,
+          private: true,
+          visibility: "private",
+          fork: false,
+          archived: false,
+          topics: ["private"],
+          pushed_at: new Date().toISOString(),
+          updated_at: new Date().toISOString(),
+        },
+      ]);
+    }
+    throw new Error(`unexpected fetch ${url.pathname}`);
+  };
+  const env = {
+    DASHBOARD_CACHE: kvStore(),
+    GITHUB_TOKEN: "shared-token",
+  };
+  try {
+    const response = await worker.fetch(
+      new Request("https://release.bar/api/users/openclaw/trust"),
+      env,
+      { waitUntil: () => undefined },
+    );
+    assert.equal(response.status, 200);
+    const body = (await response.json()) as TrustProfilePayload;
+    assert.deepEqual(paths, ["/users/openclaw", "/orgs/openclaw/repos"]);
+    assert.equal(body.type, "org");
+    assert.equal(body.profileKind, "org_signal");
+    assert.equal(body.scoreLabel, "org signal");
+    assert.equal(body.stats.totalStars, 900);
+    assert.deepEqual(
+      body.topRepositories.map((repo) => repo.fullName),
+      ["openclaw/openclaw"],
+    );
+    assert.equal(body.orgs.length, 0);
+    assert.ok(body.reasons.includes("organization account"));
+    assert.equal(
+      body.factors.find((factor) => factor.key === "orgs"),
+      undefined,
+    );
+    assert.equal(
+      body.factors.find((factor) => factor.key === "builder")?.label,
+      "repository footprint",
+    );
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("worker refreshes stale trust profiles in the background", async () => {
+  const generatedAt = new Date(Date.now() - 7 * 60 * 60 * 1000).toISOString();
+  const staleProfile: TrustProfilePayload = {
+    login: "principal",
+    type: "user",
+    profileKind: "user_trust",
+    scoreLabel: "trust score",
+    avatarUrl: "https://avatars.githubusercontent.com/u/10",
+    url: "https://github.com/principal",
+    name: "Old Principal",
+    company: null,
+    bio: null,
+    location: null,
+    blog: null,
+    twitterUsername: null,
+    followers: 1,
+    following: 0,
+    publicRepos: 1,
+    publicGists: 0,
+    accountCreatedAt: "2020-01-01T00:00:00Z",
+    accountUpdatedAt: "2026-05-16T12:00:00Z",
+    accountAgeDays: 1000,
+    score: 10,
+    tier: "low",
+    reasons: [],
+    dimensions: { trust: 0, influence: 0, builder: 0, recency: 0, risk: 100 },
+    factors: [],
+    orgs: [],
+    topRepositories: [],
+    stats: {
+      totalStars: 0,
+      totalForks: 0,
+      recentRepositories: 0,
+      activeRepositories: 0,
+      publicOrganizations: 0,
+      languages: [],
+      topics: [],
+    },
+    generatedAt,
+    cache: {
+      state: "fresh",
+      stale: false,
+      generatedAt,
+      message: "bounded public GitHub profile signals",
+    },
+  };
+  const cache = kvStore({
+    "trust-profile:v4:principal": JSON.stringify(staleProfile),
+  });
+  const queued: Promise<unknown>[] = [];
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (input) => {
+    const url = new URL(String(input));
+    if (url.pathname === "/users/principal") {
+      return Response.json({
+        login: "principal",
+        avatar_url: "https://avatars.githubusercontent.com/u/10",
+        html_url: "https://github.com/principal",
+        type: "User",
+        name: "New Principal",
+        company: "GitHub",
+        bio: "Principal software engineer building developer tools",
+        location: "San Francisco",
+        blog: "https://principal.dev",
+        twitter_username: "principal",
+        followers: 2500,
+        following: 120,
+        public_repos: 80,
+        public_gists: 9,
+        created_at: "2012-01-01T00:00:00Z",
+        updated_at: "2026-05-16T12:00:00Z",
+      });
+    }
+    if (url.pathname === "/users/principal/orgs") {
+      return Response.json([
+        {
+          login: "github",
+          avatar_url: "https://avatars.githubusercontent.com/u/9919",
+          description: "How people build software",
+        },
+      ]);
+    }
+    if (url.pathname === "/users/principal/repos") {
+      return Response.json([
+        {
+          full_name: "principal/release-tools",
+          html_url: "https://github.com/principal/release-tools",
+          description: "Release tooling",
+          language: "TypeScript",
+          stargazers_count: 120,
+          forks_count: 12,
+          fork: false,
+          archived: false,
+          topics: ["release", "developer-tools"],
+          pushed_at: new Date().toISOString(),
+          updated_at: new Date().toISOString(),
+        },
+      ]);
+    }
+    throw new Error(`unexpected fetch ${url.pathname}`);
+  };
+  try {
+    const response = await worker.fetch(
+      new Request("https://release.bar/api/users/principal/trust"),
+      {
+        DASHBOARD_CACHE: cache,
+        GITHUB_TOKEN: "shared-token",
+      },
+      { waitUntil: (promise) => queued.push(promise) },
+    );
+    assert.equal(response.status, 200);
+    const body = (await response.json()) as TrustProfilePayload;
+    assert.equal(body.cache.state, "stale");
+    assert.equal(body.cache.message, "refreshing trust profile");
+    assert.equal(body.name, "Old Principal");
+    assert.equal(queued.length, 1);
+    await Promise.all(queued);
+    const refreshed = JSON.parse(
+      (await cache.get("trust-profile:v4:principal")) ?? "{}",
+    ) as TrustProfilePayload;
+    assert.equal(refreshed.name, "New Principal");
+    assert.equal(refreshed.cache.state, "fresh");
   } finally {
     globalThis.fetch = originalFetch;
   }
@@ -3903,6 +5179,157 @@ test("worker surfaces mixed-account dashboards as shared-quota", async () => {
   }
 });
 
+test("worker keeps signed-in mixed-account dashboards on shared release scans", async () => {
+  const sessionId = "session-mixed-dashboard";
+  const exp = Math.floor(Date.now() / 1000) + 600;
+  const authCookie = await signedJson("test-secret", { id: sessionId, exp });
+  const env = {
+    AUTH_COOKIE_SECRET: "test-secret",
+    DASHBOARD_CACHE: kvStore({
+      [`auth:session:${sessionId}`]: JSON.stringify({
+        user: {
+          id: 1,
+          login: "octocat",
+          name: null,
+          avatarUrl: "https://avatars.githubusercontent.com/u/1",
+          url: "https://github.com/octocat",
+        },
+        accessToken: "user-token",
+        iat: exp - 600,
+        exp,
+      }),
+    }),
+    GITHUB_APP_ID: "123",
+    GITHUB_APP_PRIVATE_KEY: "private-key",
+    GITHUB_TOKEN: "shared-token",
+  };
+  const graphqlIncludeReleases: boolean[] = [];
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (input, init) => {
+    const url = new URL(String(input));
+    const authorization = new Headers(init?.headers).get("authorization");
+    if (url.pathname === "/user/installations") {
+      assert.equal(authorization, "Bearer user-token");
+      return Response.json({ installations: [] });
+    }
+    if (url.pathname === "/users/openclaw") {
+      assert.equal(authorization, "Bearer shared-token");
+      return Response.json({ login: "openclaw", type: "Organization" });
+    }
+    if (url.pathname === "/users/steipete") {
+      assert.equal(authorization, "Bearer shared-token");
+      return Response.json({ login: "steipete", type: "User" });
+    }
+    if (url.pathname === "/graphql") {
+      assert.equal(authorization, "Bearer shared-token");
+      const body = JSON.parse(String(init?.body ?? "{}")) as {
+        variables?: { includeReleases?: boolean };
+      };
+      graphqlIncludeReleases.push(Boolean(body.variables?.includeReleases));
+      return Response.json(
+        {
+          data: {
+            repositoryOwner: {
+              __typename: "User",
+              repositories: {
+                pageInfo: { hasNextPage: false, endCursor: null },
+                nodes: [],
+              },
+            },
+          },
+        },
+        {
+          headers: {
+            "x-ratelimit-limit": "5000",
+            "x-ratelimit-remaining": "4996",
+            "x-ratelimit-reset": String(Math.floor(Date.parse("2026-05-15T13:00:00Z") / 1000)),
+            "x-ratelimit-resource": "graphql",
+          },
+        },
+      );
+    }
+    throw new Error(`unexpected fetch ${url.pathname}`);
+  };
+  try {
+    const response = await worker.fetch(
+      new Request("https://release.bar/api/openclaw?owners=steipete", {
+        headers: { cookie: `rd_session=${authCookie}` },
+      }),
+      env,
+      { waitUntil: () => undefined },
+    );
+    assert.equal(response.status, 200);
+    const body = (await response.json()) as DashboardPayload;
+    assert.deepEqual(graphqlIncludeReleases, [true, true]);
+    assert.equal(body.cache?.quota?.source, "shared");
+    assert.equal(body.cache?.quota?.remaining, 4996);
+    assert.doesNotMatch(body.cache?.message ?? "", /release scan skipped/);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("worker keeps unsynced app-configured owner dashboards metadata-only", async () => {
+  const env = {
+    DASHBOARD_CACHE: kvStore(),
+    GITHUB_APP_ID: "123",
+    GITHUB_APP_PRIVATE_KEY: "private-key",
+  };
+  const fetchedPaths: string[] = [];
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (input) => {
+    const url = new URL(String(input));
+    fetchedPaths.push(url.pathname);
+    if (url.pathname === "/users/owner") {
+      return Response.json({
+        login: "owner",
+        type: "User",
+        avatar_url: "https://avatars.githubusercontent.com/u/1",
+        html_url: "https://github.com/owner",
+      });
+    }
+    if (url.pathname === "/users/owner/repos") {
+      return Response.json([
+        {
+          owner: { login: "owner" },
+          name: "repo",
+          full_name: "owner/repo",
+          description: null,
+          html_url: "https://github.com/owner/repo",
+          default_branch: "main",
+          language: "TypeScript",
+          topics: ["releasebar"],
+          stargazers_count: 10,
+          forks_count: 1,
+          open_issues_count: 2,
+          archived: false,
+          pushed_at: "2026-01-02T00:00:00Z",
+          updated_at: "2026-01-02T00:00:00Z",
+          fork: false,
+          private: false,
+        },
+      ]);
+    }
+    throw new Error(`unexpected fetch ${url.pathname}`);
+  };
+  try {
+    const response = await worker.fetch(new Request("https://release.bar/api/owner"), env, {
+      waitUntil: () => undefined,
+    });
+    assert.equal(response.status, 200);
+    const body = (await response.json()) as DashboardPayload;
+    assert.deepEqual(fetchedPaths, ["/users/owner", "/users/owner/repos"]);
+    assert.equal(response.headers.get("cache-control"), "private, no-store");
+    assert.equal(response.headers.get("vary"), "cookie");
+    assert.equal(body.projects[0]?.version, "repo search");
+    assert.equal(body.projects[0]?.commitsSinceRelease, null);
+    assert.match(body.cache?.message ?? "", /release scan skipped/);
+    assert.equal(await env.DASHBOARD_CACHE.get("hot:index:v3"), null);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
 test("worker uses GitHub App installation token for cold owner dashboards", async () => {
   const { privateKey } = generateKeyPairSync("rsa", {
     modulusLength: 2048,
@@ -4555,7 +5982,7 @@ test("cache keys include owner, schema, and visibility flags", () => {
       includeUnreleased: true,
       schemaVersion: 5,
     }),
-    "dashboard:v5:openclaw:forks-noarchived-unreleased",
+    "dashboard:v5:openclaw:forks-noarchived-unreleased-release",
   );
   assert.equal(
     dashboardCacheKey({
@@ -4564,7 +5991,15 @@ test("cache keys include owner, schema, and visibility flags", () => {
       repos: ["Steipete/Oracle"],
       schemaVersion: 5,
     }),
-    "dashboard:v5:openclaw:noforks-noarchived-released:sources-2dgec2fqc87xi",
+    "dashboard:v5:openclaw:noforks-noarchived-released-release:sources-2dgec2fqc87xi",
+  );
+  assert.equal(
+    dashboardCacheKey({
+      owner: "openclaw",
+      includeReleaseData: false,
+      schemaVersion: 5,
+    }),
+    "dashboard:v5:openclaw:noforks-noarchived-released-metadata",
   );
   assert.equal(
     dashboardCacheKey({
@@ -5636,6 +7071,88 @@ test("dashboard repo scan cap stops giant owners after recent repos", async () =
   assert.equal(payload.totals.repos, 2);
   assert.equal(payload.cache?.capped, true);
   assert.match(payload.cache?.message ?? "", /scanned 2 recently pushed repos/);
+});
+
+test("dashboard metadata-only mode skips release hydration", async () => {
+  const repo = (name: string) => ({
+    owner: { login: "owner" },
+    name,
+    full_name: `owner/${name}`,
+    description: null,
+    html_url: `https://github.com/owner/${name}`,
+    default_branch: "main",
+    language: null,
+    stargazers_count: 0,
+    forks_count: 0,
+    open_issues_count: 0,
+    archived: false,
+    pushed_at: "2026-01-02T00:00:00Z",
+    updated_at: "2026-01-02T00:00:00Z",
+    fork: false,
+    private: false,
+  });
+  const unexpectedHydrationFetches: string[] = [];
+
+  const payload = await buildDashboard({
+    title: "ReleaseBar",
+    subtitle: "test",
+    canonicalDomain: "example.com",
+    owners: [{ type: "user", login: "owner" }],
+    includeForks: false,
+    includeArchived: false,
+    includeUnreleased: true,
+    includeReleaseData: false,
+    repoLimit: 2,
+    repoScanLimit: 2,
+    fetch: async (url) => {
+      const path = new URL(String(url)).pathname;
+      if (path === "/users/owner/repos") {
+        return Response.json([repo("one"), repo("two"), repo("three")]);
+      }
+      unexpectedHydrationFetches.push(path);
+      return Response.json([]);
+    },
+  });
+
+  assert.deepEqual(unexpectedHydrationFetches, []);
+  assert.deepEqual(
+    payload.projects.map((project) => project.name),
+    ["one", "two"],
+  );
+  assert.deepEqual(
+    payload.projects.map((project) => project.version),
+    ["repo search", "repo search"],
+  );
+  assert.equal(payload.projects[0]?.commitsSinceRelease, null);
+  assert.match(payload.cache?.message ?? "", /release scan skipped/);
+});
+
+test("dashboard metadata-only released-only mode keeps released-only semantics", async () => {
+  const fetchedPaths: string[] = [];
+
+  const payload = await buildDashboard({
+    title: "ReleaseBar",
+    subtitle: "test",
+    canonicalDomain: "example.com",
+    owners: [{ type: "user", login: "owner" }],
+    includeForks: false,
+    includeArchived: false,
+    includeUnreleased: false,
+    includeReleaseData: false,
+    repoLimit: 2,
+    repoScanLimit: 2,
+    fetch: async (url) => {
+      const path = new URL(String(url)).pathname;
+      fetchedPaths.push(path);
+      return Response.json([]);
+    },
+  });
+
+  assert.deepEqual(fetchedPaths, []);
+  assert.deepEqual(payload.projects, []);
+  assert.equal(payload.totals.repos, 0);
+  assert.equal(payload.totals.unreleased, 0);
+  assert.match(payload.cache?.message ?? "", /release scan skipped/);
 });
 
 test("dashboard repo scan cap marks full page boundary truncation as capped", async () => {

--- a/scripts/lib/dashboard.ts
+++ b/scripts/lib/dashboard.ts
@@ -16,6 +16,7 @@ export type DashboardBuildOptions = {
   includeForks: boolean;
   includeArchived: boolean;
   includeUnreleased?: boolean;
+  includeReleaseData?: boolean;
   excludeRepos?: string[];
   includeRepos?: string[];
   initialProjects?: Project[];
@@ -155,7 +156,7 @@ type GraphQLRepoNode = {
   isPrivate: boolean;
   pushedAt: string | null;
   updatedAt: string | null;
-  releases: {
+  releases?: {
     nodes: Array<{
       tagName: string;
       name: string | null;
@@ -163,7 +164,7 @@ type GraphQLRepoNode = {
       isDraft?: boolean;
       publishedAt: string | null;
     } | null>;
-  };
+  } | null;
 };
 
 type GraphQLRepoPage = {
@@ -294,6 +295,7 @@ export function dashboardCacheKey(options: {
   includeForks?: boolean;
   includeArchived?: boolean;
   includeUnreleased?: boolean;
+  includeReleaseData?: boolean;
   schemaVersion?: number;
 }): string {
   const schemaVersion = options.schemaVersion ?? 1;
@@ -301,6 +303,7 @@ export function dashboardCacheKey(options: {
     options.includeForks ? "forks" : "noforks",
     options.includeArchived ? "archived" : "noarchived",
     options.includeUnreleased ? "unreleased" : "released",
+    options.includeReleaseData === false ? "metadata" : "release",
   ].join("-");
   const owners = (options.owners ?? []).map(slugOwner).sort().join(",");
   const repos = (options.repos ?? [])
@@ -504,7 +507,12 @@ async function githubGraphql<T>(
 }
 
 const ownerReposQuery = /* GraphQL */ `
-  query ReleaseBarOwnerRepos($login: String!, $first: Int!, $after: String) {
+  query ReleaseBarOwnerRepos(
+    $login: String!
+    $first: Int!
+    $after: String
+    $includeReleases: Boolean!
+  ) {
     repositoryOwner(login: $login) {
       __typename
       repositories(
@@ -553,7 +561,8 @@ const ownerReposQuery = /* GraphQL */ `
           isPrivate
           pushedAt
           updatedAt
-          releases(first: 10, orderBy: { field: CREATED_AT, direction: DESC }) {
+          releases(first: 10, orderBy: { field: CREATED_AT, direction: DESC })
+            @include(if: $includeReleases) {
             nodes {
               tagName
               name
@@ -569,7 +578,7 @@ const ownerReposQuery = /* GraphQL */ `
 `;
 
 function graphQlRepo(node: GraphQLRepoNode): GitHubRepo {
-  const latestRelease = node.releases.nodes.find(
+  const latestRelease = node.releases?.nodes.find(
     (release) => release?.tagName && !release.isDraft && release.publishedAt,
   );
   return {
@@ -613,6 +622,7 @@ async function ownerReposGraphqlPage(
   client: GitHubClient,
   owner: Owner,
   page: number,
+  includeReleaseData: boolean,
 ): Promise<GitHubRepo[] | null> {
   const cursorKey = `${owner.type}:${slugOwner(owner.login)}`;
   const cursors = client.graphqlCursors.get(cursorKey) ?? [null];
@@ -624,6 +634,7 @@ async function ownerReposGraphqlPage(
     login: owner.login,
     first: 100,
     after,
+    includeReleases: includeReleaseData,
   });
   const repositoryOwner = body?.data?.repositoryOwner;
   if (!repositoryOwner) {
@@ -668,10 +679,11 @@ async function githubCount(client: GitHubClient, pathname: string): Promise<numb
 async function ownerRepos(
   client: GitHubClient,
   owner: Owner,
+  includeReleaseData: boolean,
   page?: number,
 ): Promise<GitHubRepo[]> {
   if (page) {
-    const graphqlRepos = await ownerReposGraphqlPage(client, owner, page);
+    const graphqlRepos = await ownerReposGraphqlPage(client, owner, page, includeReleaseData);
     if (graphqlRepos) {
       return graphqlRepos;
     }
@@ -832,8 +844,12 @@ async function repoSummary(
   };
 }
 
-function projectCacheKey(repo: GitHubRepo, includeUnreleased: boolean): string {
-  return `repo:v1:${repo.full_name.toLowerCase()}:${includeUnreleased ? "unreleased" : "released"}`;
+function projectCacheKey(
+  repo: GitHubRepo,
+  includeUnreleased: boolean,
+  includeReleaseData: boolean,
+): string {
+  return `repo:v1:${repo.full_name.toLowerCase()}:${includeUnreleased ? "unreleased" : "released"}:${includeReleaseData ? "release" : "metadata"}`;
 }
 
 function projectCacheSignature(repo: GitHubRepo): string {
@@ -851,8 +867,9 @@ async function readProjectCache(
   cache: ProjectCache | undefined,
   repo: GitHubRepo,
   includeUnreleased: boolean,
+  includeReleaseData: boolean,
 ): Promise<Omit<Project, "freshness"> | null> {
-  const raw = await cache?.get(projectCacheKey(repo, includeUnreleased));
+  const raw = await cache?.get(projectCacheKey(repo, includeUnreleased, includeReleaseData));
   if (!raw) return null;
   try {
     const cached = JSON.parse(raw) as ProjectCacheEntry;
@@ -866,10 +883,11 @@ async function writeProjectCache(
   cache: ProjectCache | undefined,
   repo: GitHubRepo,
   includeUnreleased: boolean,
+  includeReleaseData: boolean,
   project: Omit<Project, "freshness">,
 ): Promise<void> {
   await cache?.put(
-    projectCacheKey(repo, includeUnreleased),
+    projectCacheKey(repo, includeUnreleased, includeReleaseData),
     JSON.stringify({
       signature: projectCacheSignature(repo),
       project,
@@ -900,6 +918,7 @@ export async function resolveOwnerType(
 }
 
 export async function buildDashboard(options: DashboardBuildOptions): Promise<DashboardPayload> {
+  const includeReleaseData = options.includeReleaseData ?? true;
   const client = githubClient(
     options.token,
     options.fetch,
@@ -952,15 +971,19 @@ export async function buildDashboard(options: DashboardBuildOptions): Promise<Da
         generatedAt,
         quota: client.quota,
         ...(progress ? { progress } : {}),
-        ...(progress && !progress.done
+        ...(!includeReleaseData
           ? {
-              message: `scanned ${progress.scanned}${progress.limit ? `/${progress.limit}` : ""} recently pushed repos; still updating`,
+              message: "release scan skipped until this account is synced with GitHub App quota",
             }
-          : capped && options.repoScanLimit
+          : progress && !progress.done
             ? {
-                message: `scanned ${options.repoScanLimit} recently pushed repos per owner`,
+                message: `scanned ${progress.scanned}${progress.limit ? `/${progress.limit}` : ""} recently pushed repos; still updating`,
               }
-            : {}),
+            : capped && options.repoScanLimit
+              ? {
+                  message: `scanned ${options.repoScanLimit} recently pushed repos per owner`,
+                }
+              : {}),
       },
       totals: {
         repos: sortedProjects.length,
@@ -973,6 +996,11 @@ export async function buildDashboard(options: DashboardBuildOptions): Promise<Da
       },
       projects: sortedProjects,
     };
+  }
+
+  if (!includeReleaseData && !options.includeUnreleased) {
+    projects.splice(0, projects.length);
+    return payload("fresh");
   }
 
   async function addRepo(repo: GitHubRepo, countLabel: string, force = false): Promise<boolean> {
@@ -991,8 +1019,19 @@ export async function buildDashboard(options: DashboardBuildOptions): Promise<Da
     seen.add(repo.full_name.toLowerCase());
     options.log?.(`fetch ${countLabel} ${repo.full_name}`);
     const includeUnreleased = Boolean(options.includeUnreleased);
-    const cached = await readProjectCache(options.projectCache, repo, includeUnreleased);
-    const project = cached ?? (await repoSummary(client, repo, includeUnreleased));
+    const cached = await readProjectCache(
+      options.projectCache,
+      repo,
+      includeUnreleased,
+      includeReleaseData,
+    );
+    const project =
+      cached ??
+      (includeReleaseData
+        ? await repoSummary(client, repo, includeUnreleased)
+        : includeUnreleased
+          ? repoSearchProject(repo)
+          : null);
     if (!project) {
       if (existingIndex >= 0) {
         projects.splice(existingIndex, 1);
@@ -1001,7 +1040,13 @@ export async function buildDashboard(options: DashboardBuildOptions): Promise<Da
       return false;
     }
     if (!cached) {
-      await writeProjectCache(options.projectCache, repo, includeUnreleased, project);
+      await writeProjectCache(
+        options.projectCache,
+        repo,
+        includeUnreleased,
+        includeReleaseData,
+        project,
+      );
     }
     const hydrated = { ...project, freshness: freshness(project) };
     if (existingIndex >= 0) {
@@ -1020,9 +1065,11 @@ export async function buildDashboard(options: DashboardBuildOptions): Promise<Da
       let ownerVisible = ownerExisting;
       let hydratedThisOwner = 0;
       let page = 1;
-      const scanLimit = options.repoScanLimit ?? Number.POSITIVE_INFINITY;
+      const scanLimit = includeReleaseData
+        ? (options.repoScanLimit ?? Number.POSITIVE_INFINITY)
+        : Number.POSITIVE_INFINITY;
       while (ownerVisible < options.repoLimit || hydratedThisOwner < scanLimit) {
-        const repos = await ownerRepos(client, owner, page);
+        const repos = await ownerRepos(client, owner, includeReleaseData, page);
         if (repos.length === 0) {
           break;
         }
@@ -1104,7 +1151,7 @@ export async function buildDashboard(options: DashboardBuildOptions): Promise<Da
   } else {
     const repos: GitHubRepo[] = [];
     for (const owner of options.owners) {
-      repos.push(...(await ownerRepos(client, owner)));
+      repos.push(...(await ownerRepos(client, owner, includeReleaseData)));
     }
 
     const uniqueRepos = [

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -34,21 +34,25 @@
     repoDetailPath,
     repoFromPath,
     validRepoSlug,
-    workersDevApiOrigin,
+    fallbackApiOrigin,
     type DiscoverPeriod,
   } from "./routing.js";
   import type {
     ApiQuota,
     ActivityRange,
+    AudienceRange,
     AuthPayload,
     DashboardPayload,
     Owner,
     OwnerActivityPayload,
     Project,
+    RepoAudienceBackfillPayload,
+    RepoAudiencePayload,
     RepoActivityRange,
     RepoDetailActivityPayload,
     RepoDetailPayload,
     RepoDetailReleaseSummary,
+    TrustProfilePayload,
   } from "./types.js";
 
   const repoRoute = repoFromPath(location.pathname);
@@ -69,6 +73,8 @@
   }
 
   const embedded = initialPageData();
+  const initialOwnerTab =
+    new URLSearchParams(location.search).get("tab") === "trust" ? "trust" : "overview";
   const storedDevMode = localStorage.getItem("releasedeck:dev-mode") === "true";
   const storedTheme = localStorage.getItem("releasedeck:theme");
   let theme: "dark" | "light" = storedTheme === "light" ? "light" : "dark";
@@ -120,6 +126,18 @@
   let repoActivity: RepoDetailActivityPayload | null = null;
   let repoActivityLoading = false;
   let repoActivityError = "";
+  let trustProfile: TrustProfilePayload | null = null;
+  let trustProfileLoading = false;
+  let trustProfileError = "";
+  let audienceRange: AudienceRange = "month";
+  let audienceQuery = "";
+  let audience: RepoAudiencePayload | null = null;
+  let audienceLoading = false;
+  let audienceError = "";
+  let audienceBackfillLoading = false;
+  let audienceBackfillMessage = "";
+  let audienceRefreshTimer: ReturnType<typeof setTimeout> | null = null;
+  let ownerTab: "overview" | "trust" = initialOwnerTab;
 
   const numberFormat = new Intl.NumberFormat("en", { notation: "compact" });
   const dateFormat = new Intl.DateTimeFormat("en", {
@@ -142,6 +160,10 @@
   const discoverLanguages = ["TypeScript", "Python", "Rust", "Go", "Swift"];
   const activityRanges: Array<{ value: ActivityRange; label: string }> = [
     { value: "day", label: "day" },
+    { value: "week", label: "week" },
+    { value: "month", label: "month" },
+  ];
+  const audienceRanges: Array<{ value: AudienceRange; label: string }> = [
     { value: "week", label: "week" },
     { value: "month", label: "month" },
   ];
@@ -250,6 +272,8 @@
   $: workTrend = repoDetail?.workTrend ?? null;
   $: showOwnerActivity =
     !repoRoute && !initialRoute.isDefault && Boolean(initialRoute.owner) && heroExtraCount === 0;
+  $: showTrustProfile = showOwnerActivity;
+  $: filteredAudienceUsers = audience ? audienceUsersMatching(audience, audienceQuery) : [];
 
   function ownerLabel(payload: DashboardPayload): string {
     if (initialRoute.isDefault) {
@@ -275,10 +299,6 @@
 
   function ownerAvatarUrl(owner: Owner): string {
     return owner.avatarUrl ?? `https://github.com/${encodeURIComponent(owner.login)}.png?size=160`;
-  }
-
-  function ownerGitHubUrl(owner: Owner): string {
-    return owner.url ?? `https://github.com/${encodeURIComponent(owner.login)}`;
   }
 
   function projectOwnerAvatarUrl(project: Project): string {
@@ -859,6 +879,23 @@
     }, delay);
   }
 
+  function scheduleAudienceRefresh(attempt: number): void {
+    if (!repoRoute) return;
+    if (audienceRefreshTimer !== null) {
+      globalThis.clearTimeout(audienceRefreshTimer);
+    }
+    if (attempt >= 8) return;
+    const delay = attempt < 3 ? 5000 : 15000;
+    audienceRefreshTimer = globalThis.setTimeout(() => {
+      audienceRefreshTimer = null;
+      if (document.hidden) {
+        scheduleAudienceRefresh(attempt);
+        return;
+      }
+      void loadRepoAudience(attempt + 1).catch(() => undefined);
+    }, delay);
+  }
+
   function scheduleRepoActivityRefresh(attempt: number): void {
     if (!repoRoute || repoSummaryRange === "release") return;
     if (repoActivityRefreshTimer !== null) {
@@ -883,9 +920,64 @@
     url.searchParams.set("range", activityRange);
     const urls = [url.toString()];
     if (initialRoute.fallbackApiPath) {
-      const fallback = new URL(path, workersDevApiOrigin);
+      const fallback = new URL(path, fallbackApiOrigin());
       fallback.searchParams.set("range", activityRange);
       urls.push(fallback.toString());
+    }
+    return urls;
+  }
+
+  function trustProfileApiPaths(): string[] {
+    if (!initialRoute.owner) return [];
+    const path = `/api/users/${encodeURIComponent(initialRoute.owner)}/trust`;
+    const urls = [new URL(path, location.origin).toString()];
+    if (initialRoute.fallbackApiPath) {
+      urls.push(new URL(path, fallbackApiOrigin()).toString());
+    }
+    return urls;
+  }
+
+  function audienceApiPath(apiPath: string): string {
+    const url = new URL(apiPath, location.origin);
+    url.pathname = `${url.pathname.replace(/\/$/, "")}/audience`;
+    url.searchParams.set("range", audienceRange);
+    return url.toString();
+  }
+
+  function audienceApiPaths(): string[] {
+    if (!repoRoute) return [];
+    const urls = [audienceApiPath(repoRoute.apiPath)];
+    if (repoRoute.fallbackApiPath) {
+      urls.push(audienceApiPath(repoRoute.fallbackApiPath));
+    }
+    return urls;
+  }
+
+  function isRepoAudiencePayload(body: unknown): body is RepoAudiencePayload {
+    if (!body || typeof body !== "object") return false;
+    const payload = body as {
+      cache?: { state?: unknown };
+      fullName?: unknown;
+      users?: unknown;
+    };
+    return (
+      typeof payload.fullName === "string" &&
+      Array.isArray(payload.users) &&
+      typeof payload.cache?.state === "string"
+    );
+  }
+
+  function audienceBackfillApiPath(apiPath: string): string {
+    const url = new URL(apiPath, location.origin);
+    url.pathname = `${url.pathname.replace(/\/$/, "")}/audience/backfill`;
+    return url.toString();
+  }
+
+  function audienceBackfillApiPaths(): string[] {
+    if (!repoRoute) return [];
+    const urls = [audienceBackfillApiPath(repoRoute.apiPath)];
+    if (repoRoute.fallbackApiPath) {
+      urls.push(audienceBackfillApiPath(repoRoute.fallbackApiPath));
     }
     return urls;
   }
@@ -899,10 +991,7 @@
     };
     const urls = [appendActivity(repoRoute.apiPath)];
     if (repoRoute.fallbackApiPath) {
-      const fallback = new URL(
-        `${repoRoute.fallbackApiPath.replace(/\/$/, "")}/activity`,
-        workersDevApiOrigin,
-      );
+      const fallback = new URL(`${repoRoute.fallbackApiPath.replace(/\/$/, "")}/activity`, fallbackApiOrigin());
       fallback.searchParams.set("range", repoSummaryRange);
       urls.push(fallback.toString());
     }
@@ -943,6 +1032,104 @@
     }
   }
 
+  async function loadTrustProfile(): Promise<void> {
+    if (!showTrustProfile) return;
+    const paths = trustProfileApiPaths();
+    if (paths.length === 0) return;
+    trustProfileLoading = !trustProfile;
+    trustProfileError = "";
+    try {
+      for (const path of paths) {
+        const response = await fetch(path);
+        const body = (await response.json().catch(() => null)) as
+          | TrustProfilePayload
+          | { error?: string; cache?: { message?: string } }
+          | null;
+        if (body && "score" in body) {
+          trustProfile = body;
+          trustProfileError = "";
+          return;
+        }
+        trustProfileError =
+          body && "error" in body
+            ? (body.error ?? "")
+            : body?.cache?.message || `trust profile failed: ${response.status}`;
+      }
+    } catch (error) {
+      trustProfileError = error instanceof Error ? error.message : String(error);
+    } finally {
+      trustProfileLoading = false;
+    }
+  }
+
+  async function loadRepoAudience(attempt = 0, bypassCache = false): Promise<void> {
+    if (!repoRoute) return;
+    const paths = audienceApiPaths();
+    if (paths.length === 0) return;
+    const requestedRange = audienceRange;
+    audienceLoading = attempt === 0 && !audience;
+    audienceError = "";
+    try {
+      for (const path of paths) {
+        const response = await fetchPayload(path, bypassCache || attempt > 0);
+        const body = (await response.json().catch(() => null)) as
+          | RepoAudiencePayload
+          | { error?: string; cache?: { message?: string } }
+          | null;
+        if (isRepoAudiencePayload(body)) {
+          if (requestedRange !== audienceRange) return;
+          audience = body;
+          audienceError = "";
+          if (body.cache.state === "stale" || body.cache.state === "warming") {
+            scheduleAudienceRefresh(attempt);
+          }
+          return;
+        }
+        audienceError =
+          body && "error" in body
+            ? (body.error ?? "")
+            : body?.cache?.message || `audience fetch failed: ${response.status}`;
+      }
+    } catch (error) {
+      audienceError = error instanceof Error ? error.message : String(error);
+    } finally {
+      audienceLoading = false;
+    }
+  }
+
+  async function backfillRepoAudience(): Promise<void> {
+    if (!repoRoute || audienceBackfillLoading) return;
+    const paths = audienceBackfillApiPaths();
+    if (paths.length === 0) return;
+    audienceBackfillLoading = true;
+    audienceBackfillMessage = "";
+    try {
+      for (const path of paths) {
+        const response = await fetch(path, { method: "POST", cache: "no-store" });
+        const body = (await response.json().catch(() => null)) as
+          | RepoAudienceBackfillPayload
+          | { error?: string; message?: string }
+          | null;
+        if (body && "ranges" in body) {
+          audienceBackfillMessage = body.ranges
+            .map((range) => `${range.range} ${range.state}`)
+            .join(" · ");
+          audience = null;
+          await loadRepoAudience(0, true);
+          return;
+        }
+        audienceBackfillMessage =
+          body && "error" in body
+            ? (body.error ?? "")
+            : body?.message || `backfill failed: ${response.status}`;
+      }
+    } catch (error) {
+      audienceBackfillMessage = error instanceof Error ? error.message : String(error);
+    } finally {
+      audienceBackfillLoading = false;
+    }
+  }
+
   function setActivityRange(range: ActivityRange): void {
     if (activityRange === range) return;
     activityRange = range;
@@ -953,6 +1140,18 @@
       activityRefreshTimer = null;
     }
     void loadOwnerActivity();
+  }
+
+  function setAudienceRange(range: AudienceRange): void {
+    if (audienceRange === range) return;
+    audienceRange = range;
+    audience = null;
+    audienceError = "";
+    if (audienceRefreshTimer !== null) {
+      globalThis.clearTimeout(audienceRefreshTimer);
+      audienceRefreshTimer = null;
+    }
+    void loadRepoAudience();
   }
 
   async function loadRepoActivity(attempt = 0): Promise<void> {
@@ -1009,6 +1208,143 @@
     const repoText = `${numberFormat.format(payload.totals.repositories)} repo${payload.totals.repositories === 1 ? "" : "s"}`;
     const eventText = `${numberFormat.format(payload.totals.events)} public event${payload.totals.events === 1 ? "" : "s"}`;
     return `${eventText} · ${repoText} · updated ${relativeDate(payload.generatedAt)}`;
+  }
+
+  function audienceMeta(payload: RepoAudiencePayload): string {
+    const total = `${numberFormat.format(audienceTotalStargazers(payload))} total stargazers`;
+    const scored = `${numberFormat.format(payload.totals.stargazersSampled)} scored profiles`;
+    const high = `${audienceShare(payload, payload.totals.highSignal, payload.totals.highSignalPercent)} high-signal`;
+    const quota = quotaLabel(payload.cache.quota);
+    return [total, scored, high, payload.cache.state, quota, `updated ${relativeDate(payload.generatedAt)}`]
+      .filter(Boolean)
+      .join(" · ");
+  }
+
+  function audienceTotalStargazers(payload: RepoAudiencePayload): number {
+    return payload.totals.stargazers ?? payload.totals.stargazersSampled;
+  }
+
+  function audienceShare(payload: RepoAudiencePayload, count: number, percent: number): string {
+    const value = Number.isFinite(percent)
+      ? percent
+      : payload.totals.stargazersSampled > 0
+        ? Math.round((count / payload.totals.stargazersSampled) * 100)
+        : 0;
+    return `${numberFormat.format(value)}%`;
+  }
+
+  function audienceUsersMatching(
+    payload: RepoAudiencePayload,
+    text: string,
+  ): RepoAudiencePayload["users"] {
+    const needle = text.trim().toLowerCase();
+    if (!needle) return payload.users;
+    return payload.users.filter((user) =>
+      [
+        user.login,
+        user.name,
+        user.company,
+        user.bio,
+        user.location,
+        user.tier,
+        ...user.reasons,
+        ...(user.factors ?? []).map((factor) => `${factor.label} ${factor.detail}`),
+        ...user.orgs.map((org) => org.login),
+        ...user.topRepositories.map((repo) => repo.fullName),
+        ...user.topRepositories.map((repo) => repo.language),
+      ]
+        .filter(Boolean)
+        .some((value) => String(value).toLowerCase().includes(needle)),
+    );
+  }
+
+  function audienceReasonText(reasons: string[]): string {
+    return reasons.length > 0 ? reasons.slice(0, 3).join(" · ") : "public profile signal";
+  }
+
+  function trustProfileAge(payload: TrustProfilePayload): string {
+    if (payload.accountAgeDays === null) return "age unknown";
+    const years = payload.accountAgeDays / 365;
+    if (years >= 1) return `${years.toFixed(years >= 10 ? 0 : 1)} years on GitHub`;
+    return `${numberFormat.format(payload.accountAgeDays)} days on GitHub`;
+  }
+
+  function trustProfileMeta(payload: TrustProfilePayload): string {
+    const quota = quotaLabel(payload.cache.quota);
+    return [
+      trustProfileAge(payload),
+      `${numberFormat.format(payload.followers)} followers`,
+      `${numberFormat.format(payload.publicRepos)} repos`,
+      quota,
+      `updated ${relativeDate(payload.generatedAt)}`,
+    ]
+      .filter(Boolean)
+      .join(" · ");
+  }
+
+  function ownerSignalLabel(payload: TrustProfilePayload | null = trustProfile): string {
+    if (payload) return payload.scoreLabel;
+    return ownerHero(data)?.type === "org" ? "org signal" : "trust";
+  }
+
+  function ownerSignalDescription(payload: TrustProfilePayload | null = trustProfile): string {
+    return payload?.type === "org" || (!payload && ownerHero(data)?.type === "org")
+      ? "bounded public GitHub organization signals"
+      : "bounded public GitHub trust signals";
+  }
+
+  function ownerSignalTabLabel(payload: TrustProfilePayload | null = trustProfile): string {
+    return payload?.type === "org" || (!payload && ownerHero(data)?.type === "org")
+      ? "org signal"
+      : "trust";
+  }
+
+  function trustDimensionEntries(payload: TrustProfilePayload): Array<[string, number]> {
+    if (payload.type === "org") {
+      return [
+        ["credibility", payload.dimensions.trust],
+        ["repo footprint", payload.dimensions.builder],
+        ["reach", payload.dimensions.influence],
+        ["profile safety", payload.dimensions.risk],
+      ];
+    }
+    return [
+      ["trust", payload.dimensions.trust],
+      ["build", payload.dimensions.builder],
+      ["reach", payload.dimensions.influence],
+      ["account safety", payload.dimensions.risk],
+    ];
+  }
+
+  function trustFactorEntries(payload: TrustProfilePayload): TrustProfilePayload["factors"] {
+    return (payload.factors ?? []).filter((factor) => factor.key !== "recency" || factor.value > 0).slice(0, 8);
+  }
+
+  function setOwnerTab(tab: "overview" | "trust"): void {
+    ownerTab = tab;
+    const url = new URL(location.href);
+    if (tab === "trust") {
+      url.searchParams.set("tab", "trust");
+    } else {
+      url.searchParams.delete("tab");
+    }
+    history.replaceState(null, "", `${url.pathname}${url.search}${url.hash}`);
+  }
+
+  function factorContribution(value: number): string {
+    if (value === 0) return "0.0";
+    return `${value > 0 ? "+" : ""}${value.toFixed(1)}`;
+  }
+
+  function audienceInsightText(user: RepoAudiencePayload["users"][number]): string {
+    const orgs = user.orgs.slice(0, 2).map((org) => `@${org.login}`).join(", ");
+    const topRepo = user.topRepositories[0];
+    return [
+      orgs ? `orgs ${orgs}` : "",
+      topRepo ? `top repo ${topRepo.fullName} · ${numberFormat.format(topRepo.stars)} stars` : "",
+    ]
+      .filter(Boolean)
+      .join(" · ");
   }
 
   function closeDashboardStream(): void {
@@ -1536,6 +1872,8 @@
     void Promise.all([
       loadAuth(),
       routeTask,
+      showTrustProfile ? loadTrustProfile() : Promise.resolve(),
+      repoRoute ? loadRepoAudience() : Promise.resolve(),
       showOwnerActivity ? loadOwnerActivity() : Promise.resolve(),
     ]).catch((error) => {
       generatedLabel = "failed";
@@ -1554,6 +1892,9 @@
     }
     if (activityRefreshTimer !== null) {
       globalThis.clearTimeout(activityRefreshTimer);
+    }
+    if (audienceRefreshTimer !== null) {
+      globalThis.clearTimeout(audienceRefreshTimer);
     }
     if (repoActivityRefreshTimer !== null) {
       globalThis.clearTimeout(repoActivityRefreshTimer);
@@ -1579,7 +1920,7 @@
       <h1>
         {#if heroOwner}
           <span class="hero-owner-title">
-            <a class="hero-owner-link" href={ownerGitHubUrl(heroOwner)} target="_blank" rel="noreferrer">
+            <a class="hero-owner-link" href={ownerDashboardPath(heroOwner.login)}>
               <img
                 class="hero-owner-avatar"
                 src={ownerAvatarUrl(heroOwner)}
@@ -1621,7 +1962,7 @@
       <p class="subtitle">
         {#if subtitleOwner}
           Release freshness for
-          <a class="subtitle-link" href={`https://github.com/${subtitleOwner}`} target="_blank" rel="noreferrer">
+          <a class="subtitle-link" href={ownerDashboardPath(subtitleOwner)}>
             @{subtitleOwner}</a
           >.
         {:else}
@@ -1630,10 +1971,10 @@
       </p>
       {#if repoRoute && repoDetail}
         <nav class="repo-actions" aria-label="Repository links">
-          <a href={repoDetail.project.url} target="_blank" rel="noreferrer">GitHub</a>
-          <a href={`${repoDetail.project.url}/releases`} target="_blank" rel="noreferrer">Releases</a>
-          <a href={repoDetail.project.issuesUrl} target="_blank" rel="noreferrer">Issues</a>
-          <a href={repoDetail.project.pullRequestsUrl} target="_blank" rel="noreferrer">PRs</a>
+          <a class="external-link" href={repoDetail.project.url} target="_blank" rel="noreferrer">GitHub</a>
+          <a class="external-link" href={`${repoDetail.project.url}/releases`} target="_blank" rel="noreferrer">Releases</a>
+          <a class="external-link" href={repoDetail.project.issuesUrl} target="_blank" rel="noreferrer">Issues</a>
+          <a class="external-link" href={repoDetail.project.pullRequestsUrl} target="_blank" rel="noreferrer">PRs</a>
         </nav>
       {/if}
     </div>
@@ -1989,13 +2330,26 @@
             </div>
             <div class="contributor-list">
               {#each repoDetail.contributors as contributor}
-                <a class="contributor-row" href={contributor.url ?? repoDetail.project.url} target="_blank" rel="noreferrer">
+                <a
+                  class="contributor-row"
+                  href={contributor.url ? ownerDashboardPath(contributor.login) : repoDetailPath(repoDetail.fullName)}
+                >
                   {#if contributor.avatarUrl}
                     <img src={contributor.avatarUrl} alt="" width="26" height="26" loading="lazy" />
                   {:else}
                     <span class="avatar-fallback" aria-hidden="true"></span>
                   {/if}
-                  <span>{contributor.login}</span>
+                  <span class="contributor-name">
+                    <span>{contributor.login}</span>
+                    {#if contributor.trustScore !== undefined}
+                      <small
+                        class={`person-score-pill tier-${contributor.trustTier ?? "low"}`}
+                        title={`trust score ${numberFormat.format(contributor.trustScore)}`}
+                      >
+                        {numberFormat.format(contributor.trustScore)}
+                      </small>
+                    {/if}
+                  </span>
                   <strong>{numberFormat.format(contributor.commits)}</strong>
                   <i style={`width: ${percent(contributor.commits, detailMaxContributorCommits)}%`}></i>
                 </a>
@@ -2017,7 +2371,7 @@
                   <span class="release-group-label">stable</span>
                   <div class="release-list">
                     {#each stableReleases as release}
-                      <a href={release.url} target="_blank" rel="noreferrer">
+                      <a class="external-link" href={release.url} target="_blank" rel="noreferrer">
                         <strong>{release.tagName}</strong>
                         <span>{shortDate(release.publishedAt)} · {relativeDate(release.publishedAt)}</span>
                       </a>
@@ -2030,7 +2384,7 @@
                   <span class="release-group-label">pre</span>
                   <div class="release-list">
                     {#each preReleases as release}
-                      <a href={release.url} target="_blank" rel="noreferrer">
+                      <a class="external-link" href={release.url} target="_blank" rel="noreferrer">
                         <strong>{release.tagName}</strong>
                         <span>{shortDate(release.publishedAt)} · {relativeDate(release.publishedAt)}</span>
                       </a>
@@ -2097,6 +2451,109 @@
             </div>
           </section>
 
+          <section class="detail-panel detail-wide audience-panel" aria-label="Recent stargazer audience">
+            <div class="panel-heading audience-heading">
+              <div>
+                <span class="panel-kicker">audience</span>
+                <h2>new stargazers</h2>
+              </div>
+              <div class="range-toggle" aria-label="Audience range">
+                {#each audienceRanges as range}
+                  <button
+                    class:active={audienceRange === range.value}
+                    type="button"
+                    aria-pressed={audienceRange === range.value}
+                    onclick={() => setAudienceRange(range.value)}
+                  >
+                    {range.label}
+                  </button>
+                {/each}
+                <button type="button" disabled={audienceBackfillLoading} onclick={backfillRepoAudience}>
+                  {audienceBackfillLoading ? "backfilling" : "backfill"}
+                </button>
+              </div>
+            </div>
+            {#if audienceBackfillMessage}
+              <p class="detail-empty audience-backfill-message">{audienceBackfillMessage}</p>
+            {/if}
+            {#if audienceLoading}
+              <p class="detail-empty">Scoring recent public stargazer profiles.</p>
+            {:else if audienceError}
+              <p class="detail-empty">{audienceError}</p>
+            {:else if audience}
+              <div class="audience-summary" aria-label={audienceMeta(audience)}>
+                <div>
+                  <span>stargazers</span>
+                  <strong>{numberFormat.format(audienceTotalStargazers(audience))}</strong>
+                </div>
+                <div>
+                  <span>high</span>
+                  <strong>{audienceShare(audience, audience.totals.highSignal, audience.totals.highSignalPercent)}</strong>
+                </div>
+                <div>
+                  <span>medium</span>
+                  <strong>{audienceShare(audience, audience.totals.mediumSignal, audience.totals.mediumSignalPercent)}</strong>
+                </div>
+                <div>
+                  <span>bots</span>
+                  <strong>{audienceShare(audience, audience.totals.bots, audience.totals.botPercent)}</strong>
+                </div>
+              </div>
+              {#if audience.users.length > 0}
+                <div class="audience-tools">
+                  <input
+                    bind:value={audienceQuery}
+                    type="search"
+                    autocomplete="off"
+                    spellcheck="false"
+                    placeholder="find people, orgs, companies, repos"
+                    aria-label="Find stargazers"
+                  />
+                  <span>
+                    {numberFormat.format(filteredAudienceUsers.length)} / {numberFormat.format(audience.users.length)}
+                  </span>
+                </div>
+                <div class="audience-list">
+                  {#each filteredAudienceUsers as user}
+                    <a class="audience-row" href={ownerDashboardPath(user.login)}>
+                      <img src={user.avatarUrl} alt="" width="34" height="34" loading="lazy" />
+                      <span class="audience-user">
+                        <strong>
+                          <span>{user.login}</span>
+                          {#if user.trustScore !== undefined}
+                            <small
+                              class={`person-score-pill tier-${user.trustTier ?? "low"}`}
+                              title={`trust score ${numberFormat.format(user.trustScore)}`}
+                            >
+                              {numberFormat.format(user.trustScore)}
+                            </small>
+                          {/if}
+                        </strong>
+                        <small>{user.name || user.company || audienceReasonText(user.reasons)}</small>
+                        {#if audienceInsightText(user)}
+                          <small>{audienceInsightText(user)}</small>
+                        {/if}
+                      </span>
+                      <span class="audience-score">
+                        <span class={`audience-tier tier-${user.tier}`}>{user.tier}</span>
+                        <strong>{numberFormat.format(user.score)}</strong>
+                        <small>{numberFormat.format(user.followers)} followers · {numberFormat.format(user.publicRepos)} repos</small>
+                      </span>
+                    </a>
+                  {/each}
+                </div>
+                <small class="audience-note">{audienceMeta(audience)} · public stargazer profile signals only</small>
+                {#if filteredAudienceUsers.length === 0}
+                  <p class="detail-empty">No stargazers match that search.</p>
+                {/if}
+              {:else}
+                <p class="detail-empty">No recent public stargazers in this range.</p>
+              {/if}
+            {:else}
+              <p class="detail-empty">Audience signals are warming.</p>
+            {/if}
+          </section>
+
           {#if showCodeChurn(repoDetail)}
             <section class="detail-panel detail-tail">
               <div class="panel-heading">
@@ -2125,7 +2582,161 @@
       {/if}
     </section>
   {:else}
-  {#if showOwnerActivity}
+  {#if showTrustProfile}
+    <nav class="owner-tabs" aria-label="Owner page sections">
+      <button
+        class:active={ownerTab === "overview"}
+        type="button"
+        aria-pressed={ownerTab === "overview"}
+        onclick={() => setOwnerTab("overview")}
+      >
+        overview
+      </button>
+      <button
+        class:active={ownerTab === "trust"}
+        type="button"
+        aria-pressed={ownerTab === "trust"}
+        onclick={() => setOwnerTab("trust")}
+      >
+        {ownerSignalTabLabel()}
+      </button>
+    </nav>
+  {/if}
+
+  {#if showTrustProfile && ownerTab === "overview"}
+    <section class="trust-snapshot" aria-label={`${ownerSignalLabel()} summary`}>
+      {#if trustProfileLoading}
+        <span class="panel-kicker">{ownerSignalTabLabel()}</span>
+        <strong>loading</strong>
+        <small>{ownerSignalDescription()}</small>
+      {:else if trustProfileError}
+        <span class="panel-kicker">{ownerSignalTabLabel()}</span>
+        <strong>unavailable</strong>
+        <small>{trustProfileError}</small>
+      {:else if trustProfile}
+        <div class="trust-snapshot-score">
+          <span class="panel-kicker">{ownerSignalLabel(trustProfile)}</span>
+          <strong>{trustProfile.score}</strong>
+          <small class={`audience-tier tier-${trustProfile.tier}`}>{trustProfile.tier}</small>
+        </div>
+        <div>
+          <span>GitHub age</span>
+          <strong>{trustProfileAge(trustProfile)}</strong>
+        </div>
+        <div>
+          <span>reach</span>
+          <strong>{numberFormat.format(trustProfile.followers)} followers</strong>
+        </div>
+        <div>
+          <span>{trustProfile.type === "org" ? "footprint" : "builder"}</span>
+          <strong>{numberFormat.format(trustProfile.stats.activeRepositories)} active repos</strong>
+        </div>
+        <p>{audienceReasonText(trustProfile.reasons)}</p>
+        <button type="button" onclick={() => setOwnerTab("trust")}>view factors</button>
+      {:else}
+        <span class="panel-kicker">{ownerSignalTabLabel()}</span>
+        <strong>pending</strong>
+        <small>{ownerSignalDescription()} will appear here.</small>
+      {/if}
+    </section>
+  {/if}
+
+  {#if showTrustProfile && ownerTab === "trust"}
+    <section class="trust-panel" aria-label={`GitHub ${ownerSignalLabel()} profile`}>
+      <div class="panel-heading">
+        <div>
+          <span class="panel-kicker">{ownerSignalTabLabel()}</span>
+          <h2>{trustProfile ? `${trustProfile.score}` : "loading"}</h2>
+        </div>
+        {#if trustProfile}
+          <span class={`audience-tier tier-${trustProfile.tier}`}>{trustProfile.tier}</span>
+        {/if}
+      </div>
+
+      {#if trustProfileLoading}
+        <p class="activity-text">Loading {ownerSignalDescription()}.</p>
+      {:else if trustProfileError}
+        <p class="activity-text muted">{trustProfileError}</p>
+      {:else if trustProfile}
+        <div class="trust-summary" aria-label={trustProfileMeta(trustProfile)}>
+          <div>
+            <span>GitHub age</span>
+            <strong>{trustProfileAge(trustProfile)}</strong>
+          </div>
+          <div>
+            <span>public reach</span>
+            <strong>{numberFormat.format(trustProfile.followers)} followers</strong>
+          </div>
+          <div>
+            <span>{trustProfile.type === "org" ? "repo footprint" : "builder proof"}</span>
+            <strong>{numberFormat.format(trustProfile.stats.activeRepositories)} active repos</strong>
+          </div>
+          <div>
+            <span>repo stars</span>
+            <strong>{numberFormat.format(trustProfile.stats.totalStars)}</strong>
+          </div>
+        </div>
+
+        <div class="trust-dimensions" aria-label={`${ownerSignalLabel(trustProfile)} dimensions`}>
+          {#each trustDimensionEntries(trustProfile) as [label, value]}
+            <span>
+              <small>{label}</small>
+              <strong>{value}</strong>
+            </span>
+          {/each}
+        </div>
+
+        {#if trustFactorEntries(trustProfile).length > 0}
+          <div class="trust-factors" aria-label={`${ownerSignalLabel(trustProfile)} factors`}>
+            {#each trustFactorEntries(trustProfile) as factor}
+              <div class:negative={factor.sentiment === "negative"}>
+                <span>
+                  <strong>{factor.label}</strong>
+                  <small>{factor.detail}</small>
+                </span>
+                <span class="factor-value">{factor.value}/{factor.maxValue}</span>
+                <b style={`--factor-width: ${Math.min(100, Math.round((factor.value / Math.max(1, factor.maxValue)) * 100))}%`}></b>
+                <em class="factor-impact">{factorContribution(factor.weightedValue)}</em>
+              </div>
+            {/each}
+          </div>
+        {/if}
+
+        <p class="trust-reasons">{audienceReasonText(trustProfile.reasons)}</p>
+
+        {#if trustProfile.topRepositories.length > 0}
+          <div class="trust-table" aria-label="Repository evidence">
+            {#each trustProfile.topRepositories as repo}
+              <a href={repoDetailPath(repo.fullName)}>
+                <span>
+                  <strong>{repo.fullName}</strong>
+                  <small>{repo.language || repo.topics.slice(0, 2).join(", ") || "public repo"}</small>
+                </span>
+                <span>{numberFormat.format(repo.stars)} stars</span>
+              </a>
+            {/each}
+          </div>
+        {/if}
+
+        <div class="trust-tags" aria-label="Profile signals">
+          {#each trustProfile.stats.languages as item}
+            <span>{item.name} × {item.count}</span>
+          {/each}
+          {#each trustProfile.stats.topics.slice(0, 4) as item}
+            <span>{item.name} × {item.count}</span>
+          {/each}
+          {#each trustProfile.orgs.slice(0, 4) as org}
+            <span>@{org.login}</span>
+          {/each}
+        </div>
+        <small class="activity-meta">{trustProfileMeta(trustProfile)} · public {trustProfile.type === "org" ? "organization" : "profile"} signals only</small>
+      {:else}
+        <p class="activity-text muted">{ownerSignalDescription()} will appear here when available.</p>
+      {/if}
+    </section>
+  {/if}
+
+  {#if showOwnerActivity && ownerTab === "overview"}
     <section class="activity-panel" aria-label="Recent public activity">
       <div class="panel-heading">
         <div>
@@ -2184,6 +2795,7 @@
     </section>
   {/if}
 
+  {#if !showTrustProfile || ownerTab === "overview"}
   <section class="console" aria-label="Project search and metrics">
     <div class="prompt">
       <span class="mark">$</span>
@@ -2421,7 +3033,7 @@
           <div class="release-cell">
             {#if isRepositorySearchProject(project)}
               <strong>repo search</strong>
-              <a class="release-version" href={project.url} target="_blank" rel="noreferrer">
+              <a class="release-version" href={repoDetailPath(project.fullName)}>
                 open repo
               </a>
               <span class:scan-pending={data?.cache?.progress?.done === false}>
@@ -2429,21 +3041,27 @@
               </span>
             {:else}
               <strong>{absoluteDate(project.releaseDate)}</strong>
-              <a
-                class="release-version"
-                href={project.releaseUrl}
-                target="_blank"
-                rel="noreferrer"
-                title={project.releaseDate ? `Open release ${project.version}` : "Open repository"}
-              >
-                {project.releaseDate ? project.version : "open repo"}
-              </a>
+              {#if project.releaseDate}
+                <a
+                  class="release-version external-link"
+                  href={project.releaseUrl}
+                  target="_blank"
+                  rel="noreferrer"
+                  title={`Open release ${project.version}`}
+                >
+                  {project.version}
+                </a>
+              {:else}
+                <a class="release-version" href={repoDetailPath(project.fullName)} title="Open repo detail">
+                  open repo
+                </a>
+              {/if}
               <span>{relativeDate(project.releaseDate)}</span>
             {/if}
           </div>
           <div class="since-cell" class:muted={!project.compareUrl || project.commitsSinceRelease === null}>
             {#if project.compareUrl && project.commitsSinceRelease !== null}
-              <a href={project.compareUrl} target="_blank" rel="noreferrer">
+              <a class="external-link" href={project.compareUrl} target="_blank" rel="noreferrer">
                 {project.commitsSinceRelease}
               </a>
             {:else}
@@ -2455,16 +3073,16 @@
             <span>{project.latestCommitSha || project.defaultBranch}</span>
           </div>
           <div class="issues-cell dev-only">
-            <a href={project.issuesUrl} target="_blank" rel="noreferrer">{project.openIssues}</a>
+            <a class="external-link" href={project.issuesUrl} target="_blank" rel="noreferrer">{project.openIssues}</a>
           </div>
           <div class="prs-cell dev-only">
-            <a href={project.pullRequestsUrl} target="_blank" rel="noreferrer">
+            <a class="external-link" href={project.pullRequestsUrl} target="_blank" rel="noreferrer">
               {project.openPullRequests}
             </a>
           </div>
           <div class="ci-cell dev-only" data-ci={project.ciState}>
             {#if project.ciUrl}
-              <a href={project.ciUrl} target="_blank" rel="noreferrer">{ciLabel(project)}</a>
+              <a class="external-link" href={project.ciUrl} target="_blank" rel="noreferrer">{ciLabel(project)}</a>
             {:else}
               {ciLabel(project)}
             {/if}
@@ -2478,13 +3096,14 @@
     </div>
   </section>
   {/if}
+  {/if}
 </main>
 
 <footer class="site-footer">
   <span>A project by</span>
-  <a href="https://steipete.me" target="_blank" rel="noreferrer">Peter Steinberger</a>
+  <a class="external-link" href="https://steipete.me" target="_blank" rel="noreferrer">Peter Steinberger</a>
   <span class="footer-separator" aria-hidden="true">.</span>
-  <a href="https://github.com/steipete/ReleaseBar/blob/main/LICENSE" target="_blank" rel="noreferrer">MIT Licensed</a>
+  <a class="external-link" href="https://github.com/steipete/ReleaseBar/blob/main/LICENSE" target="_blank" rel="noreferrer">MIT Licensed</a>
 </footer>
 
 <CommandPalette

--- a/src/routing.ts
+++ b/src/routing.ts
@@ -28,6 +28,7 @@ export type RouteOptions = {
 
 export const workerApiOrigin = "";
 export const workersDevApiOrigin = "https://releasedeck-api.steipete.workers.dev";
+const localWorkerApiPort = "8787";
 const ownerListKey = "owners";
 const repoListKey = "repos";
 const discoverLanguageKey = "hotLang";
@@ -39,6 +40,27 @@ const discoverPeriodValues = new Set<DiscoverPeriod>([
   "year",
   "releasebar",
 ]);
+
+type RouteLocation = {
+  protocol: string;
+  hostname: string;
+  port: string;
+};
+
+function currentRouteLocation(): RouteLocation | null {
+  return (globalThis as { location?: RouteLocation }).location ?? null;
+}
+
+export function fallbackApiOrigin(currentLocation = currentRouteLocation()): string {
+  if (
+    currentLocation &&
+    (currentLocation.hostname === "127.0.0.1" || currentLocation.hostname === "localhost") &&
+    currentLocation.port !== localWorkerApiPort
+  ) {
+    return `${currentLocation.protocol}//${currentLocation.hostname}:${localWorkerApiPort}`;
+  }
+  return workersDevApiOrigin;
+}
 
 export function ownerFromPath(pathname: string): string | null {
   const [first] = pathname.split("/").filter(Boolean);
@@ -96,7 +118,7 @@ export function repoFromPath(pathname: string, apiOrigin = workerApiOrigin): Rep
     repo,
     fullName,
     apiPath: `${apiOrigin}${apiPath}`,
-    fallbackApiPath: apiOrigin === "" ? `${workersDevApiOrigin}${apiPath}` : null,
+    fallbackApiPath: apiOrigin === "" ? `${fallbackApiOrigin()}${apiPath}` : null,
   };
 }
 
@@ -159,7 +181,7 @@ export function dashboardRoute(
     return {
       owner: null,
       apiPath: `${apiOrigin}${apiPath}`,
-      fallbackApiPath: apiOrigin === "" ? `${workersDevApiOrigin}${apiPath}` : null,
+      fallbackApiPath: apiOrigin === "" ? `${fallbackApiOrigin()}${apiPath}` : null,
       label: custom ? "custom deck" : "GitHub Hot",
       isDefault: !custom,
       extraOwners,
@@ -173,7 +195,7 @@ export function dashboardRoute(
   return {
     owner,
     apiPath: `${apiOrigin}${ownerPath}`,
-    fallbackApiPath: apiOrigin === "" ? `${workersDevApiOrigin}${ownerPath}` : null,
+    fallbackApiPath: apiOrigin === "" ? `${fallbackApiOrigin()}${ownerPath}` : null,
     label:
       extraOwners.length > 0 || repos.length > 0
         ? `@${owner} +${extraOwners.length + repos.length}`

--- a/src/styles.css
+++ b/src/styles.css
@@ -459,8 +459,87 @@ h1 {
   background: rgba(156, 255, 87, 0.075);
 }
 
-/* Owner activity */
+/* Trust profile and owner activity */
 
+.owner-tabs {
+  display: flex;
+  gap: 8px;
+  margin: -8px 0 12px;
+}
+
+.owner-tabs button {
+  min-height: 34px;
+  border-color: var(--line);
+  background: rgba(8, 9, 8, 0.45);
+  color: var(--muted);
+  font-size: 13px;
+}
+
+.owner-tabs button.active {
+  border-color: color-mix(in srgb, var(--green) 58%, var(--line-strong));
+  background: rgba(156, 255, 87, 0.075);
+  color: var(--text);
+}
+
+.trust-snapshot {
+  display: grid;
+  grid-template-columns: 120px repeat(3, minmax(0, 1fr)) minmax(180px, 1.3fr) auto;
+  align-items: center;
+  gap: 10px;
+  margin: -2px 0 18px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  padding: 14px 16px;
+  background: rgba(16, 19, 15, 0.68);
+}
+
+.trust-snapshot > div {
+  min-width: 0;
+}
+
+.trust-snapshot span:not(.audience-tier),
+.trust-snapshot small:not(.audience-tier) {
+  display: block;
+  overflow: hidden;
+  color: var(--muted);
+  font-size: 11px;
+  text-overflow: ellipsis;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+
+.trust-snapshot strong {
+  display: block;
+  overflow: hidden;
+  margin-top: 3px;
+  color: var(--text);
+  font-size: 15px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.trust-snapshot-score strong {
+  color: var(--cyan);
+  font-size: 26px;
+  line-height: 1;
+}
+
+.trust-snapshot p {
+  min-width: 0;
+  margin: 0;
+  overflow: hidden;
+  color: var(--text);
+  font-size: 13px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.trust-snapshot button {
+  min-height: 32px;
+  white-space: nowrap;
+}
+
+.trust-panel,
 .activity-panel {
   display: grid;
   gap: 12px;
@@ -507,6 +586,182 @@ h1 {
 
 .activity-text.muted {
   color: var(--muted);
+}
+
+.trust-summary,
+.trust-dimensions {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 8px;
+}
+
+.trust-summary div,
+.trust-dimensions span {
+  min-width: 0;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  padding: 10px 11px;
+  background: rgba(8, 9, 8, 0.44);
+}
+
+.trust-summary span,
+.trust-dimensions small,
+.trust-table small,
+.trust-table > a > span:last-child {
+  color: var(--muted);
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0;
+}
+
+.trust-summary strong,
+.trust-dimensions strong {
+  display: block;
+  margin-top: 4px;
+  overflow: hidden;
+  color: var(--text);
+  font-size: 15px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.trust-dimensions strong {
+  font-size: 18px;
+}
+
+.trust-dimensions span:last-child strong {
+  color: var(--green);
+}
+
+.trust-factors {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 7px;
+}
+
+.trust-factors div {
+  position: relative;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 62px 52px;
+  align-items: center;
+  gap: 8px 12px;
+  min-height: 56px;
+  overflow: hidden;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  padding: 8px 10px;
+  background: rgba(8, 9, 8, 0.38);
+}
+
+.trust-factors strong,
+.trust-factors small {
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.trust-factors strong {
+  color: var(--text);
+  font-size: 13px;
+}
+
+.trust-factors small,
+.trust-factors .factor-value,
+.trust-factors .factor-impact {
+  color: var(--muted);
+  font-size: 11px;
+  font-style: normal;
+  text-align: right;
+}
+
+.trust-factors b {
+  grid-column: 1 / -1;
+  grid-row: 2;
+  display: block;
+  width: 100%;
+  height: 3px;
+  overflow: hidden;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.trust-factors em {
+  grid-column: 3;
+  grid-row: 1;
+}
+
+.trust-factors b::after {
+  display: block;
+  width: var(--factor-width);
+  height: 100%;
+  border-radius: inherit;
+  background: var(--green);
+  content: "";
+}
+
+.trust-factors .negative b::after {
+  background: var(--amber);
+}
+
+.trust-factors .negative .factor-impact {
+  color: var(--amber);
+}
+
+.trust-reasons {
+  margin: 0;
+  color: var(--text);
+  font-size: 14px;
+  line-height: 1.45;
+}
+
+.trust-table {
+  display: grid;
+  gap: 6px;
+}
+
+.trust-table a {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 12px;
+  min-height: 44px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  padding: 8px 10px;
+  background: rgba(8, 9, 8, 0.42);
+  color: var(--text);
+}
+
+.trust-table a:hover,
+.trust-table a:focus-visible {
+  border-color: var(--green);
+  color: var(--green);
+  outline: 0;
+}
+
+.trust-table strong,
+.trust-table small {
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.trust-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 7px;
+}
+
+.trust-tags span {
+  min-height: 28px;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  padding: 6px 9px;
+  background: rgba(8, 9, 8, 0.42);
+  color: var(--muted);
+  font-size: 12px;
 }
 
 .activity-stats,
@@ -1410,6 +1665,20 @@ body.dev-mode .table-head .since-heading .label-compact {
   text-underline-offset: 3px;
 }
 
+.external-link::after {
+  display: inline-block;
+  width: 0.82em;
+  height: 0.82em;
+  margin-left: 0.32em;
+  background: color-mix(in srgb, var(--muted) 78%, transparent);
+  content: "";
+  vertical-align: -0.08em;
+  -webkit-mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M15 3h6v6'/%3E%3Cpath d='M10 14 21 3'/%3E%3Cpath d='M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6'/%3E%3C/svg%3E")
+    center / contain no-repeat;
+  mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M15 3h6v6'/%3E%3Cpath d='M10 14 21 3'/%3E%3Cpath d='M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6'/%3E%3C/svg%3E")
+    center / contain no-repeat;
+}
+
 .since-cell a,
 .since-cell {
   color: var(--amber);
@@ -1775,6 +2044,212 @@ body.dev-mode .table-head .since-heading .label-compact {
   font-size: 12px;
 }
 
+.audience-panel {
+  display: grid;
+  gap: 16px;
+}
+
+.audience-heading {
+  align-items: center;
+  margin-bottom: 0;
+}
+
+.audience-summary {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 10px;
+}
+
+.audience-summary div {
+  min-width: 0;
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  padding: 12px;
+  background: rgba(8, 9, 8, 0.36);
+}
+
+.audience-summary span,
+.audience-score small,
+.audience-note {
+  color: var(--muted);
+  font-size: 12px;
+}
+
+.audience-summary span {
+  display: block;
+}
+
+.audience-summary strong {
+  display: block;
+  margin-top: 7px;
+  color: var(--green);
+  font-size: 22px;
+  line-height: 1;
+}
+
+.audience-tools {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 10px;
+}
+
+.audience-tools input {
+  width: 100%;
+  min-width: 0;
+  height: 38px;
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  padding: 0 11px;
+  background: rgba(8, 9, 8, 0.46);
+  color: var(--text);
+  font: inherit;
+  outline: 0;
+}
+
+.audience-tools input:focus {
+  border-color: rgba(156, 255, 87, 0.62);
+}
+
+.audience-tools span {
+  color: var(--muted);
+  font-size: 12px;
+  white-space: nowrap;
+}
+
+.audience-list {
+  display: grid;
+  gap: 8px;
+  max-height: 540px;
+  overflow: auto;
+  padding-right: 2px;
+}
+
+.audience-backfill-message {
+  margin: -2px 0 0;
+  color: var(--amber);
+}
+
+.audience-row {
+  display: grid;
+  grid-template-columns: 34px minmax(0, 1fr) 118px;
+  align-items: center;
+  gap: 12px;
+  min-width: 0;
+  min-height: 68px;
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  padding: 9px 10px;
+  background: rgba(8, 9, 8, 0.28);
+}
+
+.audience-row:hover,
+.audience-row:focus-visible {
+  border-color: rgba(156, 255, 87, 0.52);
+  background: rgba(156, 255, 87, 0.055);
+  color: var(--text);
+  outline: 0;
+}
+
+.audience-row img {
+  width: 34px;
+  height: 34px;
+  border: 1px solid var(--line-strong);
+  border-radius: 50%;
+  background: var(--panel-2);
+}
+
+.audience-user,
+.audience-score {
+  display: grid;
+  min-width: 0;
+  gap: 4px;
+}
+
+.audience-user strong,
+.audience-user small,
+.audience-score small {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.audience-user strong {
+  display: inline-flex;
+  min-width: 0;
+  align-items: center;
+  gap: 8px;
+  color: var(--text);
+  font-size: 14px;
+}
+
+.audience-user strong > span {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.audience-user small {
+  color: var(--muted);
+  font-size: 12px;
+}
+
+.audience-score {
+  grid-template-columns: auto auto;
+  align-items: center;
+  justify-content: end;
+  justify-items: end;
+  gap: 5px 8px;
+  text-align: right;
+}
+
+.audience-score > strong {
+  grid-column: 2;
+  grid-row: 1;
+  color: var(--cyan);
+  font-size: 20px;
+  line-height: 1;
+}
+
+.audience-score > .audience-tier {
+  grid-column: 1;
+  grid-row: 1;
+}
+
+.audience-score > small {
+  grid-column: 1 / -1;
+}
+
+.audience-tier {
+  display: inline-flex;
+  min-height: 20px;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid var(--line-strong);
+  border-radius: 999px;
+  padding: 0 8px;
+  color: var(--muted);
+  font-size: 11px;
+  line-height: 1;
+  text-transform: uppercase;
+}
+
+.audience-tier.tier-high {
+  border-color: color-mix(in srgb, var(--green) 58%, var(--line-strong));
+  color: var(--green);
+}
+
+.audience-tier.tier-medium {
+  border-color: color-mix(in srgb, var(--amber) 58%, var(--line-strong));
+  color: var(--amber);
+}
+
+.audience-tier.tier-bot {
+  border-color: color-mix(in srgb, var(--violet) 58%, var(--line-strong));
+  color: var(--violet);
+}
+
 .contributor-list,
 .release-groups,
 .language-bars {
@@ -1802,10 +2277,41 @@ body.dev-mode .table-head .since-heading .label-compact {
   background: var(--panel-2);
 }
 
-.contributor-row span {
+.contributor-row > span {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+.contributor-name {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+}
+
+.contributor-name > span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.person-score-pill {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 auto;
+  min-width: 24px;
+  min-height: 18px;
+  border: 1px solid color-mix(in srgb, var(--muted) 28%, transparent);
+  border-radius: 4px;
+  padding: 0 6px;
+  background: rgba(255, 255, 255, 0.035);
+  color: color-mix(in srgb, var(--muted) 82%, var(--text));
+  font-size: 11px;
+  font-weight: 700;
+  line-height: 1;
+  opacity: 0.72;
 }
 
 .contributor-row strong {
@@ -2154,6 +2660,69 @@ body.dev-mode .table-head .since-heading .label-compact {
     gap: 2px;
   }
 
+  .audience-summary {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .trust-summary,
+  .trust-dimensions {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .owner-tabs,
+  .trust-snapshot {
+    margin-right: 0;
+    margin-left: 0;
+  }
+
+  .trust-snapshot {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .trust-snapshot p,
+  .trust-snapshot button {
+    grid-column: 1 / -1;
+  }
+
+  .trust-factors {
+    grid-template-columns: 1fr;
+  }
+
+  .project {
+    grid-template-columns: 1fr;
+    margin: 10px;
+    border: 1px solid var(--line);
+    border-radius: var(--radius);
+    overflow: hidden;
+    background: color-mix(in srgb, var(--panel) 38%, transparent);
+  }
+
+  .trust-factors div {
+    grid-template-columns: minmax(0, 1fr) 58px 48px;
+  }
+
+  .trust-factors em {
+    grid-column: 3;
+    grid-row: 1;
+  }
+
+  .audience-tools {
+    grid-template-columns: 1fr;
+    align-items: start;
+  }
+
+  .audience-row {
+    grid-template-columns: 34px minmax(0, 1fr);
+  }
+
+  .audience-score {
+    grid-column: 1 / -1;
+    grid-template-columns: auto auto minmax(0, 1fr);
+    align-items: center;
+    justify-items: start;
+    text-align: left;
+  }
+
   .metrics .metric-action {
     border-top: 1px solid var(--line);
   }
@@ -2186,7 +2755,7 @@ body.dev-mode .table-head .since-heading .label-compact {
     border: 1px solid var(--line);
     border-radius: var(--radius);
     overflow: hidden;
-    background: color-mix(in srgb, var(--panel) 38%, transparent);
+    background: rgba(16, 19, 15, 0.38);
   }
 
   .project > div {

--- a/src/types.ts
+++ b/src/types.ts
@@ -215,6 +215,68 @@ export type OwnerActivityPayload = {
   summary?: OwnerActivitySummary;
 };
 
+export type TrustProfileRepository = {
+  fullName: string;
+  url: string;
+  description: string | null;
+  language: string | null;
+  stars: number;
+  forks: number;
+  updatedAt: string | null;
+  topics: string[];
+};
+
+export type TrustProfileSignalCount = {
+  name: string;
+  count: number;
+};
+
+export type TrustProfilePayload = {
+  login: string;
+  type: "user" | "org";
+  profileKind: "user_trust" | "org_signal";
+  scoreLabel: "trust score" | "org signal";
+  avatarUrl: string;
+  url: string;
+  name: string | null;
+  company: string | null;
+  bio: string | null;
+  location: string | null;
+  blog: string | null;
+  twitterUsername: string | null;
+  followers: number;
+  following: number;
+  publicRepos: number;
+  publicGists: number;
+  accountCreatedAt: string | null;
+  accountUpdatedAt: string | null;
+  accountAgeDays: number | null;
+  score: number;
+  tier: AudienceScoreTier;
+  reasons: string[];
+  dimensions: AudienceScoreDimensions;
+  factors: AudienceScoreFactor[];
+  orgs: RepoAudienceOrg[];
+  topRepositories: TrustProfileRepository[];
+  stats: {
+    totalStars: number;
+    totalForks: number;
+    recentRepositories: number;
+    activeRepositories: number;
+    publicOrganizations: number;
+    languages: TrustProfileSignalCount[];
+    topics: TrustProfileSignalCount[];
+  };
+  generatedAt: string;
+  cache: {
+    state: "fresh" | "stale" | "error";
+    stale: boolean;
+    generatedAt: string;
+    message?: string;
+    quota?: ApiQuota;
+  };
+};
+
 export type RepoDetailActivityPayload = {
   fullName: string;
   range: ActivityRange;
@@ -245,6 +307,8 @@ export type RepoDetailContributor = {
   avatarUrl: string | null;
   url: string | null;
   commits: number;
+  trustScore?: number;
+  trustTier?: AudienceScoreTier;
 };
 
 export type RepoDetailRelease = {
@@ -295,6 +359,108 @@ export type RepoDetailReleaseSummary = {
   commitCount: number | null;
   commitsUsed: number;
   message?: string;
+};
+
+export type AudienceRange = "week" | "month";
+
+export type AudienceScoreTier = "high" | "medium" | "low" | "bot";
+
+export type AudienceScoreDimensions = {
+  trust: number;
+  influence: number;
+  builder: number;
+  recency: number;
+  risk: number;
+};
+
+export type AudienceScoreFactor = {
+  key: "age" | "profile" | "orgs" | "reach" | "builder" | "recency" | "risk";
+  label: string;
+  value: number;
+  maxValue: number;
+  weight: number;
+  weightedValue: number;
+  detail: string;
+  sentiment: "positive" | "neutral" | "negative";
+};
+
+export type RepoAudienceOrg = {
+  login: string;
+  description: string | null;
+};
+
+export type RepoAudienceTopRepository = {
+  fullName: string;
+  url: string;
+  description: string | null;
+  language: string | null;
+  stars: number;
+  forks: number;
+  updatedAt: string | null;
+};
+
+export type RepoAudienceUser = {
+  login: string;
+  avatarUrl: string;
+  url: string;
+  name: string | null;
+  company: string | null;
+  bio: string | null;
+  location: string | null;
+  followers: number;
+  publicRepos: number;
+  starredAt: string | null;
+  score: number;
+  tier: AudienceScoreTier;
+  trustScore?: number;
+  trustTier?: AudienceScoreTier;
+  reasons: string[];
+  dimensions: AudienceScoreDimensions;
+  factors: AudienceScoreFactor[];
+  orgs: RepoAudienceOrg[];
+  topRepositories: RepoAudienceTopRepository[];
+  accountCreatedAt: string | null;
+};
+
+export type RepoAudiencePayload = {
+  fullName: string;
+  range: AudienceRange;
+  generatedAt: string;
+  cache: {
+    state: "fresh" | "stale" | "warming" | "error";
+    stale: boolean;
+    generatedAt: string;
+    message?: string;
+    quota?: ApiQuota;
+  };
+  totals: {
+    stargazers: number;
+    stargazersSampled: number;
+    highSignal: number;
+    mediumSignal: number;
+    lowSignal: number;
+    bots: number;
+    highSignalPercent: number;
+    mediumSignalPercent: number;
+    lowSignalPercent: number;
+    botPercent: number;
+  };
+  users: RepoAudienceUser[];
+};
+
+export type RepoAudienceBackfillPayload = {
+  fullName: string;
+  ranges: Array<{
+    range: AudienceRange;
+    state: "busy" | "fresh" | "rebuilt";
+    users: number;
+    generatedAt: string;
+  }>;
+  quota: {
+    source: ApiQuota["source"];
+    account: string | null;
+  };
+  message: string;
 };
 
 export type RepoDetailPayload = {

--- a/worker/index.ts
+++ b/worker/index.ts
@@ -1,4 +1,10 @@
 import {
+  calculateAudienceScore,
+  type AudienceOrgSignal,
+  type AudienceRepoSignal,
+  type AudienceScoreTier,
+} from "../scripts/lib/audience.js";
+import {
   buildDashboard,
   dashboardCacheKey,
   GitHubRateLimitError,
@@ -28,6 +34,10 @@ import {
   gitHubRepositorySchema,
   gitHubSearchRepositoryListSchema,
   gitHubSearchCountSchema,
+  gitHubStargazerListSchema,
+  gitHubUserOrganizationListSchema,
+  gitHubUserProfileSchema,
+  gitHubUserRepositoryListSchema,
   hotIndexSchema,
   parseGitHubResponse,
   safeJsonParse,
@@ -36,9 +46,14 @@ import {
   type GitHubInstallationRepository,
   type GitHubPublicEvent,
   type GitHubSearchRepository,
+  type GitHubStargazer,
+  type GitHubUserOrganization,
+  type GitHubUserProfile,
+  type GitHubUserRepository,
 } from "./schemas.js";
 import type {
   ApiQuota,
+  AudienceRange,
   AuthInstallation,
   AuthPayload,
   AuthUser,
@@ -51,10 +66,14 @@ import type {
   OwnerActivityRepository,
   OwnerActivitySummary,
   Project,
+  RepoAudiencePayload,
+  RepoAudienceUser,
   RepoDetailActivityPayload,
   RepoDetailPayload,
   RepoDetailReleaseSummary,
   RepoDetailWorkTrend,
+  AudienceScoreFactor,
+  TrustProfilePayload,
 } from "../src/types.js";
 
 type KVNamespace = {
@@ -107,6 +126,11 @@ type ExecutionContext = {
   waitUntil(promise: Promise<unknown>): void;
 };
 
+type UserTrustSignal = {
+  score: number;
+  tier: AudienceScoreTier;
+};
+
 const fullTtlMs = 60 * 60 * 1000;
 const dashboardStorageTtlSeconds = 90 * 24 * 60 * 60;
 const progressTtlSeconds = 7 * 24 * 60 * 60;
@@ -131,6 +155,12 @@ const discoverHydrateBatchSize = 12;
 const discoverCacheTtlMs = 60 * 60 * 1000;
 const repoDetailCacheTtlMs = 6 * 60 * 60 * 1000;
 const repoDetailWarmingRefreshMs = 30 * 1000;
+const repoAudienceCacheTtlMs = 6 * 60 * 60 * 1000;
+const repoAudienceUserTtlSeconds = 7 * 24 * 60 * 60;
+const repoAudienceStargazerLimit = 30;
+const repoAudienceDeepUserLimit = 12;
+const repoAudienceRanges: AudienceRange[] = ["week", "month"];
+const repoAudienceUserRepoLimit = 8;
 const releaseSummaryPromptVersion = 1;
 const releaseSummaryCommitLimit = 500;
 const activitySummaryPromptVersion = 2;
@@ -165,6 +195,24 @@ function isRepoDetailApiPath(pathname: string): boolean {
   return parts.length === 4 && parts[0] === "api" && parts[1] === "repos";
 }
 
+function isRepoAudienceApiPath(pathname: string): boolean {
+  const parts = pathname.split("/").filter(Boolean);
+  return (
+    parts.length === 5 && parts[0] === "api" && parts[1] === "repos" && parts[4] === "audience"
+  );
+}
+
+function isRepoAudienceBackfillApiPath(pathname: string): boolean {
+  const parts = pathname.split("/").filter(Boolean);
+  return (
+    parts.length === 6 &&
+    parts[0] === "api" &&
+    parts[1] === "repos" &&
+    parts[4] === "audience" &&
+    parts[5] === "backfill"
+  );
+}
+
 function isRepoActivityApiPath(pathname: string): boolean {
   const parts = pathname.split("/").filter(Boolean);
   return (
@@ -177,6 +225,21 @@ function isOwnerActivityApiPath(pathname: string): boolean {
   return parts.length === 3 && parts[0] === "api" && parts[2] === "activity";
 }
 
+function isOwnerEventsApiPath(pathname: string): boolean {
+  const parts = pathname.split("/").filter(Boolean);
+  return parts.length === 3 && parts[0] === "api" && parts[2] === "events";
+}
+
+function isOwnerApiPath(pathname: string): boolean {
+  const parts = pathname.split("/").filter(Boolean);
+  return parts.length === 2 && parts[0] === "api";
+}
+
+function isTrustProfileApiPath(pathname: string): boolean {
+  const parts = pathname.split("/").filter(Boolean);
+  return parts.length === 4 && parts[0] === "api" && parts[1] === "users" && parts[3] === "trust";
+}
+
 type DashboardRequest = {
   owners: Owner[];
   includeRepos: string[];
@@ -184,6 +247,7 @@ type DashboardRequest = {
   subtitle: string;
   key: string;
   url: URL;
+  includeReleaseData: boolean;
   token?: string;
   quotaSource?: ApiQuota["source"];
   quotaAccount?: string | null;
@@ -200,10 +264,38 @@ type GitHubAuditArea =
   | "discover"
   | "owner-activity"
   | "repo-activity"
+  | "repo-audience"
   | "repo-detail"
   | "release-summary"
+  | "trust-profile"
   | "social-card"
   | "auth";
+
+const githubAuditAreas = new Set<GitHubAuditArea>([
+  "dashboard",
+  "discover",
+  "owner-activity",
+  "repo-activity",
+  "repo-audience",
+  "repo-detail",
+  "release-summary",
+  "trust-profile",
+  "social-card",
+  "auth",
+]);
+
+function githubRequestOptions(
+  acceptOrAuditArea = "application/vnd.github+json",
+  auditArea: GitHubAuditArea = "repo-detail",
+): { accept: string; auditArea: GitHubAuditArea } {
+  if (githubAuditAreas.has(acceptOrAuditArea as GitHubAuditArea)) {
+    return {
+      accept: "application/vnd.github+json",
+      auditArea: acceptOrAuditArea as GitHubAuditArea,
+    };
+  }
+  return { accept: acceptOrAuditArea, auditArea };
+}
 
 type ProfileInput = {
   includeOwners?: unknown;
@@ -645,7 +737,11 @@ async function resolveOwners(
   return owners;
 }
 
-async function initialPageData(url: URL, env: Env): Promise<InitialPageData | null> {
+async function initialPageData(
+  request: Request,
+  url: URL,
+  env: Env,
+): Promise<InitialPageData | null> {
   const repo = repoFullNameFromPath(url.pathname);
   if (repo) return cachedRepoInitialData(env, repo);
 
@@ -653,7 +749,7 @@ async function initialPageData(url: URL, env: Env): Promise<InitialPageData | nu
   const custom =
     ownerListFromUrl(url, primaryOwner ?? undefined).length > 0 || repoListFromUrl(url).length > 0;
   if (primaryOwner || custom) {
-    return cachedDashboardInitialData(env, url, primaryOwner);
+    return cachedDashboardInitialData(request, env, url, primaryOwner);
   }
   if ((url.searchParams.get("period") ?? "").toLowerCase() === "releasebar") {
     return cachedHotInitialData(env);
@@ -676,7 +772,7 @@ async function assetResponse(request: Request, env: Env): Promise<Response> {
     const originalUrl = new URL(request.url);
     const label = socialLabel(originalUrl);
     const image = `${originalUrl.origin}/og/${encodeURIComponent(label)}.svg`;
-    const initialData = await initialPageData(originalUrl, env).catch(() => null);
+    const initialData = await initialPageData(request, originalUrl, env).catch(() => null);
     const html = injectInitialPageData(
       (await response.text())
         .replace(/<title>.*?<\/title>/, `<title>${escapeHtml(label)} · release.bar</title>`)
@@ -707,7 +803,9 @@ async function assetResponse(request: Request, env: Env): Promise<Response> {
     headers.delete("content-length");
     headers.delete("etag");
     headers.set("content-type", "text/html; charset=utf-8");
-    headers.set("cache-control", "public, max-age=300");
+    for (const [name, value] of Object.entries(authDependentAppShellHeaders(request, env))) {
+      headers.set(name, value);
+    }
     return new Response(html, {
       status: response.status,
       headers,
@@ -980,6 +1078,235 @@ function jsonResponse(body: unknown, status = 200, headers: Record<string, strin
       ...headers,
     },
   });
+}
+
+function openApiSpec(origin: string): Record<string, unknown> {
+  const cacheState = {
+    type: "object",
+    required: ["state", "stale", "generatedAt"],
+    properties: {
+      state: { enum: ["fresh", "stale", "partial", "warming", "error"] },
+      stale: { type: "boolean" },
+      generatedAt: { type: "string", format: "date-time" },
+      message: { type: "string" },
+      quota: {
+        type: "object",
+        properties: {
+          source: { enum: ["app", "shared", "anonymous"] },
+          account: { type: ["string", "null"] },
+          remaining: { type: ["number", "null"] },
+          limit: { type: ["number", "null"] },
+          resetAt: { type: ["string", "null"], format: "date-time" },
+          resource: { type: ["string", "null"] },
+        },
+      },
+    },
+  };
+  const trustFactor = {
+    type: "object",
+    required: [
+      "key",
+      "label",
+      "value",
+      "maxValue",
+      "weight",
+      "weightedValue",
+      "detail",
+      "sentiment",
+    ],
+    properties: {
+      key: { enum: ["age", "profile", "orgs", "reach", "builder", "recency", "risk"] },
+      label: { type: "string" },
+      value: { type: "number" },
+      maxValue: { type: "number" },
+      weight: { type: "number" },
+      weightedValue: { type: "number" },
+      detail: { type: "string" },
+      sentiment: { enum: ["positive", "neutral", "negative"] },
+    },
+  };
+  const trustDimensions = {
+    type: "object",
+    required: ["trust", "influence", "builder", "recency", "risk"],
+    properties: {
+      trust: { type: "number", minimum: 0, maximum: 100 },
+      influence: { type: "number", minimum: 0, maximum: 100 },
+      builder: { type: "number", minimum: 0, maximum: 100 },
+      recency: { type: "number", minimum: 0, maximum: 100 },
+      risk: {
+        type: "number",
+        minimum: 0,
+        maximum: 100,
+        description: "Account safety score. 100 means no obvious public-account risk signals.",
+      },
+    },
+  };
+  return {
+    openapi: "3.1.0",
+    info: {
+      title: "ReleaseBar Public API",
+      version: "0.1.0",
+      description:
+        "Cached public GitHub release, people trust, org signal, and stargazer audience context for dashboards and PR-triage agents.",
+    },
+    servers: [{ url: origin }],
+    paths: {
+      "/api/users/{login}/trust": {
+        get: {
+          summary: "Get cached public people trust or org signal context for one GitHub profile",
+          parameters: [{ name: "login", in: "path", required: true, schema: { type: "string" } }],
+          responses: {
+            "200": {
+              description: "People trust or org signal profile",
+              content: {
+                "application/json": { schema: { $ref: "#/components/schemas/TrustProfile" } },
+              },
+            },
+          },
+        },
+      },
+      "/api/repos/{owner}/{repo}/audience": {
+        get: {
+          summary: "Get cached recent stargazer audience percentages and scored users",
+          parameters: [
+            { name: "owner", in: "path", required: true, schema: { type: "string" } },
+            { name: "repo", in: "path", required: true, schema: { type: "string" } },
+            { name: "range", in: "query", schema: { enum: ["week", "month"], default: "month" } },
+          ],
+          responses: {
+            "200": {
+              description: "Repository audience",
+              content: {
+                "application/json": { schema: { $ref: "#/components/schemas/RepoAudience" } },
+              },
+            },
+            "403": { description: "GitHub App quota required for cold audience builds" },
+          },
+        },
+      },
+      "/api/repos/{owner}/{repo}/audience/backfill": {
+        post: {
+          summary: "Warm week and month audience caches with GitHub App quota",
+          parameters: [
+            { name: "owner", in: "path", required: true, schema: { type: "string" } },
+            { name: "repo", in: "path", required: true, schema: { type: "string" } },
+          ],
+          responses: {
+            "200": {
+              description: "Backfill state",
+              content: {
+                "application/json": {
+                  schema: { $ref: "#/components/schemas/RepoAudienceBackfill" },
+                },
+              },
+            },
+            "403": { description: "GitHub App quota required" },
+          },
+        },
+      },
+    },
+    components: {
+      schemas: {
+        CacheState: cacheState,
+        TrustDimensions: trustDimensions,
+        TrustFactor: trustFactor,
+        TrustProfile: {
+          type: "object",
+          required: [
+            "login",
+            "type",
+            "profileKind",
+            "scoreLabel",
+            "score",
+            "tier",
+            "dimensions",
+            "factors",
+            "cache",
+          ],
+          properties: {
+            login: { type: "string" },
+            type: { enum: ["user", "org"] },
+            profileKind: { enum: ["user_trust", "org_signal"] },
+            scoreLabel: { enum: ["trust score", "org signal"] },
+            score: { type: "number", minimum: 0, maximum: 100 },
+            tier: { enum: ["high", "medium", "low", "bot"] },
+            accountAgeDays: { type: ["number", "null"] },
+            reasons: { type: "array", items: { type: "string" } },
+            dimensions: { $ref: "#/components/schemas/TrustDimensions" },
+            factors: { type: "array", items: { $ref: "#/components/schemas/TrustFactor" } },
+            cache: { $ref: "#/components/schemas/CacheState" },
+          },
+        },
+        RepoAudience: {
+          type: "object",
+          required: ["fullName", "range", "totals", "users", "cache"],
+          properties: {
+            fullName: { type: "string" },
+            range: { enum: ["week", "month"] },
+            totals: {
+              type: "object",
+              required: [
+                "stargazers",
+                "stargazersSampled",
+                "highSignalPercent",
+                "mediumSignalPercent",
+                "lowSignalPercent",
+                "botPercent",
+              ],
+              properties: {
+                stargazers: { type: "number" },
+                stargazersSampled: { type: "number" },
+                highSignal: { type: "number" },
+                mediumSignal: { type: "number" },
+                lowSignal: { type: "number" },
+                bots: { type: "number" },
+                highSignalPercent: { type: "number", minimum: 0, maximum: 100 },
+                mediumSignalPercent: { type: "number", minimum: 0, maximum: 100 },
+                lowSignalPercent: { type: "number", minimum: 0, maximum: 100 },
+                botPercent: { type: "number", minimum: 0, maximum: 100 },
+              },
+            },
+            users: {
+              type: "array",
+              items: {
+                type: "object",
+                properties: {
+                  login: { type: "string" },
+                  score: { type: "number" },
+                  tier: { enum: ["high", "medium", "low", "bot"] },
+                  trustScore: { type: "number" },
+                  trustTier: { enum: ["high", "medium", "low", "bot"] },
+                  dimensions: { $ref: "#/components/schemas/TrustDimensions" },
+                },
+              },
+            },
+            cache: { $ref: "#/components/schemas/CacheState" },
+          },
+        },
+        RepoAudienceBackfill: {
+          type: "object",
+          required: ["fullName", "ranges", "quota", "message"],
+          properties: {
+            fullName: { type: "string" },
+            ranges: {
+              type: "array",
+              items: {
+                type: "object",
+                properties: {
+                  range: { enum: ["week", "month"] },
+                  state: { enum: ["busy", "fresh", "rebuilt"] },
+                  users: { type: "number" },
+                  generatedAt: { type: "string", format: "date-time" },
+                },
+              },
+            },
+            quota: { type: "object" },
+            message: { type: "string" },
+          },
+        },
+      },
+    },
+  };
 }
 
 function redirectResponse(
@@ -1515,6 +1842,27 @@ async function acknowledgedInstallations(
 
 function appTokenConfigured(env: Env): boolean {
   return Boolean(env.GITHUB_APP_ID && env.GITHUB_APP_PRIVATE_KEY);
+}
+
+async function dashboardReleaseDataAllowed(
+  request: Request,
+  env: Env,
+  sources: TokenSources,
+  token: RequestToken | null | undefined,
+): Promise<boolean> {
+  if (!appTokenConfigured(env) || token?.quotaSource === "app") return true;
+  if (sourceAccounts(sources).length <= 1) return false;
+  return Boolean(await currentSession(request, env));
+}
+
+function authDependentDashboardHeaders(env: Env): Record<string, string> {
+  return appTokenConfigured(env) ? { "cache-control": "private, no-store", vary: "cookie" } : {};
+}
+
+function authDependentAppShellHeaders(request: Request, env: Env): Record<string, string> {
+  return appTokenConfigured(env) && parseCookies(request).has(sessionCookie)
+    ? { "cache-control": "private, no-store", vary: "cookie" }
+    : { "cache-control": "public, max-age=300" };
 }
 
 function normalizePrivateKey(value: string): string {
@@ -2203,6 +2551,7 @@ async function partialDashboardPayload(
       dashboardCacheKey({
         owner,
         ...options,
+        includeReleaseData: dashboard.includeReleaseData,
         schemaVersion: dashboardSchemaVersion,
       }),
     ),
@@ -2211,6 +2560,7 @@ async function partialDashboardPayload(
         owner: "custom",
         repos: [repo],
         ...options,
+        includeReleaseData: dashboard.includeReleaseData,
         schemaVersion: dashboardSchemaVersion,
       }),
     ),
@@ -2311,11 +2661,16 @@ async function rememberHotDashboard(
   payload: DashboardPayload,
 ): Promise<void> {
   if (payload.options?.includeForks) return;
+  if (!payload.projects.some(canContributeToHotDashboard)) return;
   const keys = await readHotIndex(env);
   const next = [key, ...keys.filter((existing) => existing !== key)].slice(0, hotIndexLimit);
   await env.DASHBOARD_CACHE?.put(hotIndexKey, JSON.stringify(next), {
     expirationTtl: dashboardStorageTtlSeconds,
   });
+}
+
+function canContributeToHotDashboard(project: Project): boolean {
+  return !project.archived && Boolean(project.releaseDate) && project.commitsSinceRelease !== null;
 }
 
 function hotDashboardPayload(
@@ -2326,7 +2681,7 @@ function hotDashboardPayload(
   const candidates = new Map<string, Project>();
   for (const dashboard of dashboards) {
     for (const project of dashboard.projects) {
-      if (project.archived || !project.releaseDate || project.commitsSinceRelease === null) {
+      if (!canContributeToHotDashboard(project)) {
         continue;
       }
       const existing = candidates.get(project.fullName.toLowerCase());
@@ -2491,11 +2846,38 @@ async function detailGitHubJson<TSchema extends GenericSchema>(
   quotaSource: ApiQuota["source"],
   quotaAccount: string | null,
   onQuota: (quota: ApiQuota) => void,
+  acceptOrAuditArea = "application/vnd.github+json",
   auditArea: GitHubAuditArea = "repo-detail",
 ): Promise<InferOutput<TSchema>> {
+  const { data } = await detailGitHubJsonWithHeaders(
+    path,
+    schema,
+    context,
+    token,
+    quotaSource,
+    quotaAccount,
+    onQuota,
+    acceptOrAuditArea,
+    auditArea,
+  );
+  return data;
+}
+
+async function detailGitHubJsonWithHeaders<TSchema extends GenericSchema>(
+  path: string,
+  schema: TSchema,
+  context: string,
+  token: string | null,
+  quotaSource: ApiQuota["source"],
+  quotaAccount: string | null,
+  onQuota: (quota: ApiQuota) => void,
+  acceptOrAuditArea = "application/vnd.github+json",
+  auditArea: GitHubAuditArea = "repo-detail",
+): Promise<{ data: InferOutput<TSchema>; headers: Headers }> {
+  const requestOptions = githubRequestOptions(acceptOrAuditArea, auditArea);
   const response = await workerFetch(`https://api.github.com${path}`, {
     headers: {
-      accept: "application/vnd.github+json",
+      accept: requestOptions.accept,
       ...(token ? { authorization: `Bearer ${token}` } : {}),
       "user-agent": "ReleaseBar",
       "x-github-api-version": "2022-11-28",
@@ -2503,7 +2885,7 @@ async function detailGitHubJson<TSchema extends GenericSchema>(
   });
   const quota = quotaFromGitHubResponse(response, quotaSource, quotaAccount);
   onQuota(quota);
-  auditGitHubTokenUse(auditArea, path, response.status, quota);
+  auditGitHubTokenUse(requestOptions.auditArea, path, response.status, quota);
   const body = await response.json().catch(() => null);
   if (!response.ok) {
     const message =
@@ -2515,7 +2897,7 @@ async function detailGitHubJson<TSchema extends GenericSchema>(
     }
     throw new Error(`GitHub API ${response.status} for ${path}: ${message}`);
   }
-  return parseGitHubResponse(schema, body, context);
+  return { data: parseGitHubResponse(schema, body, context), headers: response.headers };
 }
 
 async function detailGitHubStats<TSchema extends GenericSchema>(
@@ -3111,7 +3493,7 @@ function unavailableActivitySummary(
 }
 
 async function activitySummaryState(
-  payload: OwnerActivityPayload,
+  payload: ActivitySummaryPayload & Pick<OwnerActivityPayload, "owner" | "range">,
   env: Env,
 ): Promise<OwnerActivitySummary> {
   const model = activitySummaryModel(env);
@@ -3848,6 +4230,1246 @@ function releaseProject(repo: InferOutput<typeof gitHubRepositorySchema>): Proje
   };
 }
 
+function audienceRangeFromUrl(url: URL): AudienceRange {
+  return url.searchParams.get("range")?.toLowerCase() === "week" ? "week" : "month";
+}
+
+function audienceRangeMs(range: AudienceRange): number {
+  return range === "week" ? 7 * 24 * 60 * 60 * 1000 : 30 * 24 * 60 * 60 * 1000;
+}
+
+function repoAudienceCacheKey(owner: string, repo: string, range: AudienceRange): string {
+  return `repo-audience:v5:${slugOwner(owner)}/${repo.toLowerCase()}:${range}`;
+}
+
+function repoAudienceUserKey(login: string): string {
+  return `audience-user:v1:${slugOwner(login)}`;
+}
+
+function repoAudienceUserOrgsKey(login: string): string {
+  return `audience-user-orgs:v1:${slugOwner(login)}`;
+}
+
+function repoAudienceUserReposKey(login: string): string {
+  return `audience-user-repos:v2:${slugOwner(login)}`;
+}
+
+function repoAudienceAgeMs(payload: RepoAudiencePayload | null): number {
+  if (!payload) return Number.POSITIVE_INFINITY;
+  const generatedAt = Date.parse(payload.generatedAt);
+  return Number.isFinite(generatedAt) ? Date.now() - generatedAt : Number.POSITIVE_INFINITY;
+}
+
+async function readRepoAudience(env: Env, key: string): Promise<RepoAudiencePayload | null> {
+  const raw = await env.DASHBOARD_CACHE?.get(key);
+  return raw ? tryJsonParse<RepoAudiencePayload>(raw, `repo audience ${key}`) : null;
+}
+
+async function writeRepoAudience(
+  env: Env,
+  key: string,
+  payload: RepoAudiencePayload,
+): Promise<void> {
+  await env.DASHBOARD_CACHE?.put(key, JSON.stringify(payload), {
+    expirationTtl: dashboardStorageTtlSeconds,
+  });
+}
+
+async function readAudienceUser(env: Env, login: string): Promise<GitHubUserProfile | null> {
+  const raw = await env.DASHBOARD_CACHE?.get(repoAudienceUserKey(login));
+  return raw ? safeJsonParse(gitHubUserProfileSchema, raw, `audience user ${login}`) : null;
+}
+
+async function writeAudienceUser(env: Env, user: GitHubUserProfile): Promise<void> {
+  await env.DASHBOARD_CACHE?.put(repoAudienceUserKey(user.login), JSON.stringify(user), {
+    expirationTtl: repoAudienceUserTtlSeconds,
+  });
+}
+
+async function readAudienceUserOrgs(
+  env: Env,
+  login: string,
+): Promise<GitHubUserOrganization[] | null> {
+  const raw = await env.DASHBOARD_CACHE?.get(repoAudienceUserOrgsKey(login));
+  return raw
+    ? safeJsonParse(gitHubUserOrganizationListSchema, raw, `audience user orgs ${login}`)
+    : null;
+}
+
+async function writeAudienceUserOrgs(
+  env: Env,
+  login: string,
+  orgs: GitHubUserOrganization[],
+): Promise<void> {
+  await env.DASHBOARD_CACHE?.put(repoAudienceUserOrgsKey(login), JSON.stringify(orgs), {
+    expirationTtl: repoAudienceUserTtlSeconds,
+  });
+}
+
+async function readAudienceUserRepos(
+  env: Env,
+  login: string,
+): Promise<GitHubUserRepository[] | null> {
+  const raw = await env.DASHBOARD_CACHE?.get(repoAudienceUserReposKey(login));
+  return raw
+    ? safeJsonParse(gitHubUserRepositoryListSchema, raw, `audience user repos ${login}`)
+    : null;
+}
+
+async function writeAudienceUserRepos(
+  env: Env,
+  login: string,
+  repos: GitHubUserRepository[],
+): Promise<void> {
+  await env.DASHBOARD_CACHE?.put(repoAudienceUserReposKey(login), JSON.stringify(repos), {
+    expirationTtl: repoAudienceUserTtlSeconds,
+  });
+}
+
+async function audienceUserProfile(
+  login: string,
+  env: Env,
+  token: string | null,
+  quotaSource: ApiQuota["source"],
+  quotaAccount: string | null,
+  onQuota: (quota: ApiQuota) => void,
+  auditArea: GitHubAuditArea = "repo-audience",
+): Promise<GitHubUserProfile | null> {
+  const cached = await readAudienceUser(env, login);
+  if (cached) return cached;
+  const user = await detailGitHubJson(
+    `/users/${encodeURIComponent(login)}`,
+    gitHubUserProfileSchema,
+    "audience user profile",
+    token,
+    quotaSource,
+    quotaAccount,
+    onQuota,
+    auditArea,
+  );
+  await writeAudienceUser(env, user);
+  return user;
+}
+
+async function recentRepoStargazers(
+  owner: string,
+  repo: string,
+  path: string,
+  token: string | null,
+  quotaSource: ApiQuota["source"],
+  quotaAccount: string | null,
+  onQuota: (quota: ApiQuota) => void,
+): Promise<GitHubStargazer[]> {
+  const graphql = await recentRepoStargazersGraphql(
+    owner,
+    repo,
+    token,
+    quotaSource,
+    quotaAccount,
+    onQuota,
+  );
+  if (graphql) return graphql;
+  return recentRepoStargazersRest(path, token, quotaSource, quotaAccount, onQuota);
+}
+
+async function recentRepoStargazersRest(
+  path: string,
+  token: string | null,
+  quotaSource: ApiQuota["source"],
+  quotaAccount: string | null,
+  onQuota: (quota: ApiQuota) => void,
+): Promise<GitHubStargazer[]> {
+  const firstPath = `${path}/stargazers?per_page=${repoAudienceStargazerLimit}`;
+  const firstPage = await detailGitHubJsonWithHeaders(
+    firstPath,
+    gitHubStargazerListSchema,
+    "repository stargazers",
+    token,
+    quotaSource,
+    quotaAccount,
+    onQuota,
+    "application/vnd.github.v3.star+json",
+  );
+  const lastPage = lastPageFromLink(firstPage.headers.get("link"));
+  if (!lastPage || lastPage <= 1) return firstPage.data;
+  const lastPath = `${firstPath}&page=${lastPage}`;
+  const last = await detailGitHubJson(
+    lastPath,
+    gitHubStargazerListSchema,
+    "repository stargazers",
+    token,
+    quotaSource,
+    quotaAccount,
+    onQuota,
+    "application/vnd.github.v3.star+json",
+  );
+  if (last.length >= repoAudienceStargazerLimit) return last;
+  const previous = await detailGitHubJson(
+    `${firstPath}&page=${lastPage - 1}`,
+    gitHubStargazerListSchema,
+    "repository stargazers",
+    token,
+    quotaSource,
+    quotaAccount,
+    onQuota,
+    "application/vnd.github.v3.star+json",
+  );
+  return [...previous, ...last].slice(-repoAudienceStargazerLimit);
+}
+
+type GraphQLStargazerEdge = {
+  starredAt: string | null;
+  node: {
+    login: string;
+    avatarUrl: string;
+    url: string;
+  } | null;
+};
+
+type GraphQLStargazerResponse = {
+  data?: {
+    repository?: {
+      stargazers?: {
+        edges?: GraphQLStargazerEdge[];
+      } | null;
+    } | null;
+  };
+  errors?: Array<{ message?: string; type?: string }>;
+};
+
+const repoStargazersQuery = /* GraphQL */ `
+  query ReleaseBarRepoStargazers($owner: String!, $name: String!, $first: Int!) {
+    repository(owner: $owner, name: $name) {
+      stargazers(first: $first, orderBy: { field: STARRED_AT, direction: DESC }) {
+        edges {
+          starredAt
+          node {
+            login
+            avatarUrl
+            url
+          }
+        }
+      }
+    }
+  }
+`;
+
+async function recentRepoStargazersGraphql(
+  owner: string,
+  repo: string,
+  token: string | null,
+  quotaSource: ApiQuota["source"],
+  quotaAccount: string | null,
+  onQuota: (quota: ApiQuota) => void,
+): Promise<GitHubStargazer[] | null> {
+  if (!token) return null;
+  const response = await workerFetch("https://api.github.com/graphql", {
+    method: "POST",
+    headers: {
+      accept: "application/vnd.github+json",
+      authorization: `Bearer ${token}`,
+      "content-type": "application/json",
+      "user-agent": "ReleaseBar",
+      "x-github-api-version": "2022-11-28",
+    },
+    body: JSON.stringify({
+      query: repoStargazersQuery,
+      variables: { owner, name: repo, first: repoAudienceStargazerLimit },
+    }),
+  });
+  const quota = quotaFromGitHubResponse(response, quotaSource, quotaAccount);
+  onQuota(quota);
+  auditGitHubTokenUse("repo-audience", "/graphql", response.status, quota);
+  const body = (await response.json().catch(() => null)) as GraphQLStargazerResponse | null;
+  const message = body?.errors
+    ?.map((error) => error.message ?? error.type)
+    .filter(Boolean)
+    .join("; ");
+  if (isRateLimitResponse(response, message ?? "")) {
+    throw new GitHubRateLimitError(
+      message ?? "GitHub GraphQL rate limit",
+      parseHeaderInt(response.headers.get("retry-after")),
+    );
+  }
+  if (!response.ok || body?.errors?.length) return null;
+  const edges = body?.data?.repository?.stargazers?.edges ?? [];
+  return edges
+    .filter(
+      (edge): edge is GraphQLStargazerEdge & { node: NonNullable<GraphQLStargazerEdge["node"]> } =>
+        Boolean(edge.node?.login),
+    )
+    .map((edge) => ({
+      starred_at: edge.starredAt,
+      user: {
+        login: edge.node.login,
+        avatar_url: edge.node.avatarUrl,
+        html_url: edge.node.url,
+      },
+    }));
+}
+
+async function audienceUserOrgs(
+  login: string,
+  env: Env,
+  token: string | null,
+  quotaSource: ApiQuota["source"],
+  quotaAccount: string | null,
+  onQuota: (quota: ApiQuota) => void,
+  auditArea: GitHubAuditArea = "repo-audience",
+): Promise<GitHubUserOrganization[]> {
+  const cached = await readAudienceUserOrgs(env, login);
+  if (cached) return cached;
+  const orgs = await detailGitHubJson(
+    `/users/${encodeURIComponent(login)}/orgs?per_page=20`,
+    gitHubUserOrganizationListSchema,
+    "audience user orgs",
+    token,
+    quotaSource,
+    quotaAccount,
+    onQuota,
+    auditArea,
+  );
+  await writeAudienceUserOrgs(env, login, orgs);
+  return orgs;
+}
+
+async function audienceUserRepos(
+  login: string,
+  env: Env,
+  token: string | null,
+  quotaSource: ApiQuota["source"],
+  quotaAccount: string | null,
+  onQuota: (quota: ApiQuota) => void,
+  profileType: GitHubUserProfile["type"] = "User",
+  auditArea: GitHubAuditArea = "repo-audience",
+): Promise<GitHubUserRepository[]> {
+  const cached = await readAudienceUserRepos(env, login);
+  if (cached) return cached;
+  const reposPath =
+    profileType === "Organization"
+      ? `/orgs/${encodeURIComponent(login)}/repos?sort=updated&type=public&per_page=${repoAudienceUserRepoLimit}`
+      : `/users/${encodeURIComponent(login)}/repos?sort=updated&type=owner&per_page=${repoAudienceUserRepoLimit}`;
+  const repos = await detailGitHubJson(
+    reposPath,
+    gitHubUserRepositoryListSchema,
+    "audience user repositories",
+    token,
+    quotaSource,
+    quotaAccount,
+    onQuota,
+    auditArea,
+  );
+  const publicRepos = repos.filter(isPublicAudienceRepository);
+  await writeAudienceUserRepos(env, login, publicRepos);
+  return publicRepos;
+}
+
+function isPublicAudienceRepository(repo: GitHubUserRepository): boolean {
+  if (repo.private === true) return false;
+  if (repo.visibility && repo.visibility !== "public") return false;
+  return true;
+}
+
+async function audienceUserInsights(
+  login: string,
+  env: Env,
+  token: string | null,
+  quotaSource: ApiQuota["source"],
+  quotaAccount: string | null,
+  onQuota: (quota: ApiQuota) => void,
+  profileType: GitHubUserProfile["type"] = "User",
+  auditArea: GitHubAuditArea = "repo-audience",
+): Promise<{ orgs: GitHubUserOrganization[]; repos: GitHubUserRepository[] }> {
+  const [orgs, repos] = await Promise.all([
+    profileType === "Organization"
+      ? Promise.resolve([])
+      : audienceUserOrgs(login, env, token, quotaSource, quotaAccount, onQuota, auditArea).catch(
+          (error) => {
+            if (isGitHubRateLimit(error)) throw error;
+            return [];
+          },
+        ),
+    audienceUserRepos(
+      login,
+      env,
+      token,
+      quotaSource,
+      quotaAccount,
+      onQuota,
+      profileType,
+      auditArea,
+    ).catch((error) => {
+      if (isGitHubRateLimit(error)) throw error;
+      return [];
+    }),
+  ]);
+  return { orgs, repos };
+}
+
+function audienceOrgSignals(orgs: GitHubUserOrganization[]): AudienceOrgSignal[] {
+  return orgs.slice(0, 8).map((org) => ({
+    login: org.login,
+    description: org.description,
+  }));
+}
+
+function audienceRepoSignals(repos: GitHubUserRepository[]): AudienceRepoSignal[] {
+  return repos
+    .filter((repo) => !repo.archived && !repo.fork)
+    .slice(0, repoAudienceUserRepoLimit)
+    .map((repo) => ({
+      fullName: repo.full_name,
+      description: repo.description,
+      url: repo.html_url,
+      language: repo.language,
+      stars: repo.stargazers_count,
+      forks: repo.forks_count,
+      updatedAt: repo.updated_at,
+      pushedAt: repo.pushed_at,
+      topics: repo.topics ?? [],
+    }));
+}
+
+function audienceUser(
+  stargazer: GitHubStargazer,
+  profile: GitHubUserProfile | null,
+  insights: { orgs: GitHubUserOrganization[]; repos: GitHubUserRepository[] } | null,
+  targetLanguage: string | null,
+  targetTopics: string[],
+): RepoAudienceUser {
+  const login = profile?.login ?? stargazer.user.login;
+  const orgs = audienceOrgSignals(insights?.orgs ?? []);
+  const repos = audienceRepoSignals(insights?.repos ?? []);
+  const score = calculateAudienceScore({
+    login,
+    followers: profile?.followers ?? 0,
+    following: profile?.following ?? 0,
+    publicRepos: profile?.public_repos ?? 0,
+    publicGists: profile?.public_gists ?? 0,
+    company: profile?.company ?? null,
+    bio: profile?.bio ?? null,
+    location: profile?.location ?? null,
+    blog: profile?.blog ?? null,
+    twitterUsername: profile?.twitter_username ?? null,
+    accountCreatedAt: profile?.created_at ?? null,
+    accountUpdatedAt: profile?.updated_at ?? null,
+    starredAt: stargazer.starred_at,
+    targetLanguage,
+    targetTopics,
+    orgs,
+    repos,
+  });
+  return {
+    login,
+    avatarUrl: profile?.avatar_url ?? stargazer.user.avatar_url,
+    url: profile?.html_url ?? stargazer.user.html_url,
+    name: profile?.name ?? null,
+    company: profile?.company ?? null,
+    bio: profile?.bio ?? null,
+    location: profile?.location ?? null,
+    followers: profile?.followers ?? 0,
+    publicRepos: profile?.public_repos ?? 0,
+    starredAt: stargazer.starred_at,
+    score: score.score,
+    tier: score.tier,
+    reasons: score.reasons,
+    dimensions: score.dimensions,
+    factors: score.factors,
+    orgs,
+    topRepositories: repos
+      .sort(
+        (a, b) => b.stars - a.stars || b.forks - a.forks || a.fullName.localeCompare(b.fullName),
+      )
+      .slice(0, 3)
+      .map((repo) => ({
+        fullName: repo.fullName,
+        url: repo.url,
+        description: repo.description,
+        language: repo.language,
+        stars: repo.stars,
+        forks: repo.forks,
+        updatedAt: repo.pushedAt ?? repo.updatedAt,
+      })),
+    accountCreatedAt: profile?.created_at ?? null,
+  };
+}
+
+function roundedPercent(value: number, total: number): number {
+  if (total <= 0) return 0;
+  return Math.round((value / total) * 100);
+}
+
+function audienceTotals(
+  users: RepoAudienceUser[],
+  totalStargazers: number,
+): RepoAudiencePayload["totals"] {
+  const count = (tier: AudienceScoreTier) => users.filter((user) => user.tier === tier).length;
+  const highSignal = count("high");
+  const mediumSignal = count("medium");
+  const lowSignal = count("low");
+  const bots = count("bot");
+  const scored = users.length;
+  return {
+    stargazers: totalStargazers,
+    stargazersSampled: scored,
+    highSignal,
+    mediumSignal,
+    lowSignal,
+    bots,
+    highSignalPercent: roundedPercent(highSignal, scored),
+    mediumSignalPercent: roundedPercent(mediumSignal, scored),
+    lowSignalPercent: roundedPercent(lowSignal, scored),
+    botPercent: roundedPercent(bots, scored),
+  };
+}
+
+function trustProfileCacheKey(login: string): string {
+  return `trust-profile:v4:${slugOwner(login)}`;
+}
+
+function trustProfileAgeMs(payload: TrustProfilePayload | null): number {
+  if (!payload) return Number.POSITIVE_INFINITY;
+  const generatedAt = Date.parse(payload.generatedAt);
+  return Number.isFinite(generatedAt) ? Date.now() - generatedAt : Number.POSITIVE_INFINITY;
+}
+
+async function readTrustProfile(env: Env, key: string): Promise<TrustProfilePayload | null> {
+  const raw = await env.DASHBOARD_CACHE?.get(key);
+  return raw ? tryJsonParse<TrustProfilePayload>(raw, `trust profile ${key}`) : null;
+}
+
+function userTrustSignal(profile: TrustProfilePayload | null): UserTrustSignal | null {
+  if (!profile || profile.profileKind !== "user_trust") return null;
+  return { score: profile.score, tier: profile.tier };
+}
+
+async function cachedUserTrustSignals(
+  env: Env,
+  logins: Array<string | null | undefined>,
+): Promise<Map<string, UserTrustSignal>> {
+  const signals = new Map<string, UserTrustSignal>();
+  if (!env.DASHBOARD_CACHE) return signals;
+  const slugs = Array.from(
+    new Set(
+      logins
+        .filter((login): login is string => Boolean(login))
+        .map(slugOwner)
+        .filter(validOwnerSlug),
+    ),
+  );
+  await Promise.all(
+    slugs.map(async (login) => {
+      const signal = userTrustSignal(await readTrustProfile(env, trustProfileCacheKey(login)));
+      if (signal) signals.set(login, signal);
+    }),
+  );
+  return signals;
+}
+
+async function withRepoAudienceTrustProfiles(
+  payload: RepoAudiencePayload,
+  env: Env,
+): Promise<RepoAudiencePayload> {
+  const signals = await cachedUserTrustSignals(
+    env,
+    payload.users.map((user) => user.login),
+  );
+  return {
+    ...payload,
+    users: payload.users.map((user) => {
+      const { trustScore: _trustScore, trustTier: _trustTier, ...base } = user;
+      const signal = signals.get(slugOwner(user.login));
+      return signal ? { ...base, trustScore: signal.score, trustTier: signal.tier } : base;
+    }),
+  };
+}
+
+async function withRepoDetailContributorTrustProfiles(
+  payload: RepoDetailPayload,
+  env: Env,
+): Promise<RepoDetailPayload> {
+  const signals = await cachedUserTrustSignals(
+    env,
+    payload.contributors.map((contributor) => contributor.login),
+  );
+  return {
+    ...payload,
+    contributors: payload.contributors.map((contributor) => {
+      const { trustScore: _trustScore, trustTier: _trustTier, ...base } = contributor;
+      const signal = signals.get(slugOwner(contributor.login));
+      return signal ? { ...base, trustScore: signal.score, trustTier: signal.tier } : base;
+    }),
+  };
+}
+
+async function writeTrustProfile(
+  env: Env,
+  key: string,
+  payload: TrustProfilePayload,
+): Promise<void> {
+  await env.DASHBOARD_CACHE?.put(key, JSON.stringify(payload), {
+    expirationTtl: dashboardStorageTtlSeconds,
+  });
+}
+
+async function refreshTrustProfile(
+  key: string,
+  login: string,
+  request: Request,
+  env: Env,
+): Promise<void> {
+  const lock = await acquireBuildLock(env, `${key}:refresh`);
+  if (!lock) return;
+  try {
+    const payload = await buildTrustProfile(login, request, env);
+    await writeTrustProfile(env, key, payload);
+  } finally {
+    await lock.release();
+  }
+}
+
+function signalCounts(
+  values: Array<string | null | undefined>,
+  limit = 5,
+): Array<{ name: string; count: number }> {
+  const counts = new Map<string, number>();
+  for (const value of values) {
+    const name = usefulSignalName(value);
+    if (!name) continue;
+    counts.set(name, (counts.get(name) ?? 0) + 1);
+  }
+  return [...counts.entries()]
+    .map(([name, count]) => ({ name, count }))
+    .sort((a, b) => b.count - a.count || a.name.localeCompare(b.name))
+    .slice(0, limit);
+}
+
+function usefulSignalName(value: string | null | undefined): string {
+  return (value ?? "").trim().toLowerCase();
+}
+
+function topTrustRepositories(repos: AudienceRepoSignal[]): TrustProfilePayload["topRepositories"] {
+  return repos
+    .sort((a, b) => b.stars - a.stars || b.forks - a.forks || a.fullName.localeCompare(b.fullName))
+    .slice(0, 5)
+    .map((repo) => ({
+      fullName: repo.fullName,
+      url: repo.url,
+      description: repo.description,
+      language: repo.language,
+      stars: repo.stars,
+      forks: repo.forks,
+      updatedAt: repo.pushedAt ?? repo.updatedAt,
+      topics: repo.topics,
+    }));
+}
+
+function clampProfileScore(value: number): number {
+  return Math.max(0, Math.min(100, Math.round(value)));
+}
+
+function scoreTier(score: number): AudienceScoreTier {
+  return score >= 70 ? "high" : score >= 40 ? "medium" : "low";
+}
+
+function retitleFactor(
+  factor: AudienceScoreFactor,
+  label: string,
+  detail: string,
+  value = factor.value,
+  maxValue = factor.maxValue,
+): AudienceScoreFactor {
+  const clamped = clampProfileScore(value);
+  return {
+    ...factor,
+    label,
+    detail,
+    value: clamped,
+    maxValue,
+    weightedValue: Math.round(clamped * factor.weight * 100) / 100,
+  };
+}
+
+function orgSignalScore(
+  base: ReturnType<typeof calculateAudienceScore>,
+  profile: GitHubUserProfile,
+  repos: AudienceRepoSignal[],
+  activeRepositories: number,
+): ReturnType<typeof calculateAudienceScore> {
+  const totalStars = repos.reduce((sum, repo) => sum + repo.stars, 0);
+  const totalForks = repos.reduce((sum, repo) => sum + repo.forks, 0);
+  const repoFootprint = clampProfileScore(
+    Math.min(Math.log10(profile.public_repos + 1) * 18, 38) +
+      Math.min(Math.log10(totalStars + totalForks + 1) * 18, 44) +
+      Math.min(activeRepositories * 4, 18),
+  );
+  const profileFields = [
+    profile.name,
+    profile.company,
+    profile.bio,
+    profile.location,
+    profile.blog,
+    profile.twitter_username,
+  ].filter((value) => typeof value === "string" && value.trim()).length;
+  const orgCredibility = clampProfileScore(
+    Math.min((daysSince(profile.created_at) ?? 0) / 90, 28) +
+      Math.min(profileFields * 8, 32) +
+      Math.min(Math.log10(profile.public_repos + 1) * 12, 24) +
+      Math.min(Math.log10(totalStars + 1) * 8, 16),
+  );
+  const reach = clampProfileScore(
+    Math.max(base.dimensions.influence, Math.min(Math.log10(totalStars + 1) * 20, 68)),
+  );
+  const dimensions = {
+    trust: orgCredibility,
+    influence: reach,
+    builder: Math.max(base.dimensions.builder, repoFootprint),
+    recency: base.dimensions.recency,
+    risk: base.dimensions.risk,
+  };
+  const score = clampProfileScore(
+    dimensions.trust * 0.24 +
+      dimensions.builder * 0.34 +
+      dimensions.influence * 0.28 +
+      dimensions.risk * 0.14,
+  );
+  const factors = base.factors
+    .filter((factor) => factor.key !== "orgs" && factor.key !== "recency")
+    .map((factor) => {
+      if (factor.key === "age") {
+        return retitleFactor(
+          factor,
+          "organization age",
+          profile.created_at
+            ? `${daysSince(profile.created_at)?.toLocaleString("en")} days on GitHub`
+            : "GitHub organization age unavailable",
+        );
+      }
+      if (factor.key === "profile") {
+        return retitleFactor(factor, "organization profile", factor.detail);
+      }
+      if (factor.key === "reach") {
+        return retitleFactor(
+          factor,
+          "project reach",
+          `${totalStars.toLocaleString("en")} stars, ${profile.followers.toLocaleString("en")} followers`,
+          reach,
+          100,
+        );
+      }
+      if (factor.key === "builder") {
+        return retitleFactor(
+          factor,
+          "repository footprint",
+          `${profile.public_repos.toLocaleString("en")} public repos, ${activeRepositories.toLocaleString("en")} recently active`,
+          repoFootprint,
+          100,
+        );
+      }
+      if (factor.key === "risk") {
+        return retitleFactor(factor, "profile safety", factor.detail);
+      }
+      return factor;
+    });
+  const reasons = [
+    "organization account",
+    profile.public_repos > 0 ? `${profile.public_repos.toLocaleString("en")} public repos` : "",
+    totalStars > 0 ? `${totalStars.toLocaleString("en")} public repo stars` : "",
+    activeRepositories > 0
+      ? `${activeRepositories.toLocaleString("en")} recently active repos`
+      : "",
+    ...base.reasons.filter(
+      (reason) =>
+        !/^\d+ public org/.test(reason) &&
+        !reason.startsWith("notable org:") &&
+        reason !== "active public builder",
+    ),
+  ].filter(Boolean);
+  return {
+    score,
+    tier: scoreTier(score),
+    reasons: reasons.length > 0 ? reasons : ["public organization signal is light"],
+    dimensions,
+    factors,
+  };
+}
+
+async function buildTrustProfile(
+  login: string,
+  request: Request,
+  env: Env,
+): Promise<TrustProfilePayload> {
+  const requestToken = await bestInstallationToken(request, env, {
+    owners: [login],
+    repos: [],
+  }).catch(() => null);
+  const token = requestToken?.token ?? env.GITHUB_TOKEN ?? null;
+  const quotaSource = requestToken?.quotaSource ?? (env.GITHUB_TOKEN ? "shared" : "anonymous");
+  const quotaAccount = requestToken?.quotaAccount ?? null;
+  let quota: ApiQuota | undefined;
+  const onQuota = (next: ApiQuota) => {
+    quota = next;
+  };
+  const profile = await audienceUserProfile(
+    login,
+    env,
+    token,
+    quotaSource,
+    quotaAccount,
+    onQuota,
+    "trust-profile",
+  );
+  if (!profile) {
+    throw new Error("GitHub profile not found");
+  }
+  const isOrg = profile.type === "Organization";
+  const { orgs, repos } = await audienceUserInsights(
+    profile.login,
+    env,
+    token,
+    quotaSource,
+    quotaAccount,
+    onQuota,
+    profile.type,
+    "trust-profile",
+  );
+  const orgSignals = audienceOrgSignals(orgs);
+  const repoSignals = audienceRepoSignals(repos);
+  const activeRepositories = repoSignals.filter((repo) => {
+    const ageDays = daysSince(repo.pushedAt ?? repo.updatedAt);
+    return ageDays !== null && ageDays <= 180;
+  }).length;
+  const baseScore = calculateAudienceScore({
+    login: profile.login,
+    followers: profile.followers,
+    following: profile.following,
+    publicRepos: profile.public_repos,
+    publicGists: profile.public_gists,
+    company: profile.company,
+    bio: profile.bio,
+    location: profile.location,
+    blog: profile.blog,
+    twitterUsername: profile.twitter_username,
+    accountCreatedAt: profile.created_at,
+    accountUpdatedAt: profile.updated_at,
+    starredAt: null,
+    orgs: orgSignals,
+    repos: repoSignals,
+  });
+  const score = isOrg
+    ? orgSignalScore(baseScore, profile, repoSignals, activeRepositories)
+    : baseScore;
+  const generatedAt = new Date().toISOString();
+  return {
+    login: profile.login,
+    type: isOrg ? "org" : "user",
+    profileKind: isOrg ? "org_signal" : "user_trust",
+    scoreLabel: isOrg ? "org signal" : "trust score",
+    avatarUrl: profile.avatar_url,
+    url: profile.html_url,
+    name: profile.name,
+    company: profile.company,
+    bio: profile.bio,
+    location: profile.location,
+    blog: profile.blog,
+    twitterUsername: profile.twitter_username,
+    followers: profile.followers,
+    following: profile.following,
+    publicRepos: profile.public_repos,
+    publicGists: profile.public_gists,
+    accountCreatedAt: profile.created_at,
+    accountUpdatedAt: profile.updated_at,
+    accountAgeDays: daysSince(profile.created_at),
+    score: score.score,
+    tier: score.tier,
+    reasons: score.reasons,
+    dimensions: score.dimensions,
+    factors: score.factors,
+    orgs: orgSignals,
+    topRepositories: topTrustRepositories(repoSignals),
+    stats: {
+      totalStars: repoSignals.reduce((sum, repo) => sum + repo.stars, 0),
+      totalForks: repoSignals.reduce((sum, repo) => sum + repo.forks, 0),
+      recentRepositories: repoSignals.length,
+      activeRepositories,
+      publicOrganizations: orgSignals.length,
+      languages: signalCounts(repoSignals.map((repo) => repo.language)),
+      topics: signalCounts(repoSignals.flatMap((repo) => repo.topics)),
+    },
+    generatedAt,
+    cache: {
+      state: "fresh",
+      stale: false,
+      generatedAt,
+      message: isOrg
+        ? "bounded public GitHub organization signals"
+        : "bounded public GitHub profile signals",
+      ...(quota ? { quota } : {}),
+    },
+  };
+}
+
+function withTrustProfileState(
+  payload: TrustProfilePayload,
+  state: TrustProfilePayload["cache"]["state"],
+  message = payload.cache.message,
+): TrustProfilePayload {
+  return {
+    ...payload,
+    cache: {
+      ...payload.cache,
+      state,
+      stale: state !== "fresh",
+      ...(message ? { message } : {}),
+    },
+  };
+}
+
+async function trustProfileResponse(
+  request: Request,
+  env: Env,
+  context: ExecutionContext,
+): Promise<Response> {
+  const url = new URL(request.url);
+  const login = slugOwner(decodeURIComponent(url.pathname.split("/")[3] ?? ""));
+  if (!validOwnerSlug(login)) {
+    return jsonResponse({ error: "invalid user" }, 400, { "cache-control": "no-store" });
+  }
+  const key = trustProfileCacheKey(login);
+  const cached = await readTrustProfile(env, key);
+  const ageMs = trustProfileAgeMs(cached);
+  if (cached && ageMs < repoAudienceCacheTtlMs) {
+    return jsonResponse(withTrustProfileState(cached, "fresh"));
+  }
+  if (cached && ageMs <= maxDisplayStaleMs) {
+    context.waitUntil(refreshTrustProfile(key, login, request, env).catch(() => undefined));
+    return jsonResponse(withTrustProfileState(cached, "stale", "refreshing trust profile"));
+  }
+  try {
+    const payload = await buildTrustProfile(login, request, env);
+    await writeTrustProfile(env, key, payload);
+    return jsonResponse(payload, 200, { "cache-control": "public, max-age=60" });
+  } catch (error) {
+    return jsonResponse(
+      {
+        error: dashboardErrorMessage(error),
+        cache: {
+          state: "error",
+          stale: true,
+          generatedAt: new Date().toISOString(),
+          message: dashboardErrorMessage(error),
+        },
+      },
+      errorStatus(error),
+      retryAfterHeaders(error),
+    );
+  }
+}
+
+function withRepoAudienceState(
+  payload: RepoAudiencePayload,
+  state: RepoAudiencePayload["cache"]["state"],
+  message = payload.cache.message,
+): RepoAudiencePayload {
+  return {
+    ...payload,
+    cache: {
+      ...payload.cache,
+      state,
+      stale: state !== "fresh",
+      ...(message ? { message } : {}),
+    },
+  };
+}
+
+async function buildRepoAudience(
+  owner: string,
+  repoName: string,
+  range: AudienceRange,
+  request: Request,
+  env: Env,
+  tokenOverride?: RequestToken | null,
+): Promise<RepoAudiencePayload> {
+  const fullName = `${slugOwner(owner)}/${repoName.toLowerCase()}`;
+  const requestToken =
+    tokenOverride ??
+    (await requestInstallationToken(request, env, {
+      owners: [],
+      repos: [fullName],
+    }).catch(() => null));
+  const token = requestToken?.token ?? env.GITHUB_TOKEN ?? null;
+  const quotaSource = requestToken?.quotaSource ?? (env.GITHUB_TOKEN ? "shared" : "anonymous");
+  const quotaAccount = requestToken?.quotaAccount ?? null;
+  let quota: ApiQuota | undefined;
+  const onQuota = (next: ApiQuota) => {
+    quota = next;
+  };
+  const path = `/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repoName)}`;
+  const repo = await detailGitHubJson(
+    path,
+    gitHubRepositorySchema,
+    "repository audience",
+    token,
+    quotaSource,
+    quotaAccount,
+    onQuota,
+  );
+  if (repo.private) {
+    throw new Error("private repositories are not visible in public dashboards");
+  }
+  const since = Date.now() - audienceRangeMs(range);
+  const stargazers = (
+    await recentRepoStargazers(owner, repoName, path, token, quotaSource, quotaAccount, onQuota)
+  ).filter((stargazer) => {
+    const starredAt = Date.parse(stargazer.starred_at ?? "");
+    return Number.isFinite(starredAt) && starredAt >= since;
+  });
+  const profileEntries = await Promise.all(
+    stargazers.map(async (stargazer) => {
+      const profile = await audienceUserProfile(
+        stargazer.user.login,
+        env,
+        token,
+        quotaSource,
+        quotaAccount,
+        onQuota,
+      ).catch((error) => {
+        if (isGitHubRateLimit(error)) throw error;
+        return null;
+      });
+      return { stargazer, profile };
+    }),
+  );
+  const shallowUsers = profileEntries.map(({ stargazer, profile }) =>
+    audienceUser(stargazer, profile, null, repo.language, repo.topics ?? []),
+  );
+  const deepLogins = new Set(
+    shallowUsers
+      .filter((user) => user.tier !== "bot")
+      .sort(
+        (a, b) =>
+          b.score - a.score ||
+          Date.parse(b.starredAt ?? "") - Date.parse(a.starredAt ?? "") ||
+          a.login.localeCompare(b.login),
+      )
+      .slice(0, repoAudienceDeepUserLimit)
+      .map((user) => user.login.toLowerCase()),
+  );
+  const users = (
+    await Promise.all(
+      profileEntries.map(async ({ stargazer, profile }) => {
+        const login = (profile?.login ?? stargazer.user.login).toLowerCase();
+        const insights = deepLogins.has(login)
+          ? await audienceUserInsights(
+              login,
+              env,
+              token,
+              quotaSource,
+              quotaAccount,
+              onQuota,
+              profile?.type ?? "User",
+            )
+          : null;
+        return audienceUser(stargazer, profile, insights, repo.language, repo.topics ?? []);
+      }),
+    )
+  ).sort(
+    (a, b) =>
+      b.score - a.score ||
+      Date.parse(b.starredAt ?? "") - Date.parse(a.starredAt ?? "") ||
+      a.login.localeCompare(b.login),
+  );
+  const generatedAt = new Date().toISOString();
+  return {
+    fullName: repo.full_name,
+    range,
+    generatedAt,
+    cache: {
+      state: "fresh",
+      stale: false,
+      generatedAt,
+      message: "public stargazer profile signals only",
+      ...(quota ? { quota } : {}),
+    },
+    totals: audienceTotals(users, repo.stargazers_count),
+    users,
+  };
+}
+
+async function refreshRepoAudience(
+  key: string,
+  owner: string,
+  repo: string,
+  range: AudienceRange,
+  request: Request,
+  env: Env,
+  tokenOverride?: RequestToken | null,
+): Promise<void> {
+  const lock = await acquireBuildLock(env, `${key}:refresh`);
+  if (!lock) return;
+  try {
+    const payload = await buildRepoAudience(owner, repo, range, request, env, tokenOverride);
+    await writeRepoAudience(env, key, payload);
+  } finally {
+    await lock.release();
+  }
+}
+
+async function repoAudienceResponse(
+  request: Request,
+  env: Env,
+  context: ExecutionContext,
+): Promise<Response> {
+  const url = new URL(request.url);
+  const [, , , rawOwner, rawRepo] = url.pathname.split("/");
+  const owner = slugOwner(decodeURIComponent(rawOwner ?? ""));
+  const repo = decodeURIComponent(rawRepo ?? "").toLowerCase();
+  const fullName = `${owner}/${repo}`;
+  if (!validRepoSlug(fullName)) {
+    return jsonResponse({ error: "invalid repository" }, 400, { "cache-control": "no-store" });
+  }
+  const range = audienceRangeFromUrl(url);
+  const key = repoAudienceCacheKey(owner, repo, range);
+  const cached = await readRepoAudience(env, key);
+  const ageMs = repoAudienceAgeMs(cached);
+  if (cached && ageMs < repoAudienceCacheTtlMs) {
+    return jsonResponse(
+      withRepoAudienceState(await withRepoAudienceTrustProfiles(cached, env), "fresh"),
+    );
+  }
+  const requestToken = appTokenConfigured(env)
+    ? await requestInstallationToken(request, env, {
+        owners: [],
+        repos: [fullName],
+      }).catch(() => null)
+    : null;
+  const canBuildAudience = !appTokenConfigured(env) || Boolean(requestToken);
+  if (cached && ageMs <= maxDisplayStaleMs) {
+    if (canBuildAudience) {
+      context.waitUntil(refreshRepoAudience(key, owner, repo, range, request, env, requestToken));
+    }
+    return jsonResponse(
+      withRepoAudienceState(
+        await withRepoAudienceTrustProfiles(cached, env),
+        "stale",
+        canBuildAudience
+          ? "refreshing repository audience signals"
+          : "connect the GitHub App for this repository to refresh audience signals",
+      ),
+    );
+  }
+  if (!canBuildAudience) {
+    return jsonResponse(
+      { error: "connect the GitHub App for this repository before building audience caches" },
+      403,
+      { "cache-control": "no-store" },
+    );
+  }
+
+  try {
+    const payload = await buildRepoAudience(owner, repo, range, request, env, requestToken);
+    await writeRepoAudience(env, key, payload);
+    return jsonResponse(await withRepoAudienceTrustProfiles(payload, env), 200, {
+      "cache-control": "public, max-age=60",
+    });
+  } catch (error) {
+    return jsonResponse(
+      {
+        error: dashboardErrorMessage(error),
+        cache: {
+          state: "error",
+          stale: true,
+          generatedAt: new Date().toISOString(),
+          message: dashboardErrorMessage(error),
+        },
+      },
+      errorStatus(error),
+      retryAfterHeaders(error),
+    );
+  }
+}
+
+async function repoAudienceBackfillResponse(request: Request, env: Env): Promise<Response> {
+  if (request.method !== "POST") {
+    return jsonResponse({ error: "backfill requires POST" }, 405, { allow: "POST" });
+  }
+  const url = new URL(request.url);
+  const [, , , rawOwner, rawRepo] = url.pathname.split("/");
+  const owner = slugOwner(decodeURIComponent(rawOwner ?? ""));
+  const repo = decodeURIComponent(rawRepo ?? "").toLowerCase();
+  const fullName = `${owner}/${repo}`;
+  if (!validRepoSlug(fullName)) {
+    return jsonResponse({ error: "invalid repository" }, 400, { "cache-control": "no-store" });
+  }
+  const requestToken = await requestInstallationToken(request, env, {
+    owners: [],
+    repos: [fullName],
+  }).catch(() => null);
+  if (!requestToken) {
+    return jsonResponse(
+      { error: "connect the GitHub App for this repository before backfilling audience caches" },
+      403,
+      { "cache-control": "no-store" },
+    );
+  }
+  const force = url.searchParams.get("force") === "1";
+  const ranges: Array<{
+    range: AudienceRange;
+    state: "busy" | "fresh" | "rebuilt";
+    users: number;
+    generatedAt: string;
+  }> = [];
+  for (const range of repoAudienceRanges) {
+    const key = repoAudienceCacheKey(owner, repo, range);
+    const cached = await readRepoAudience(env, key);
+    const ageMs = repoAudienceAgeMs(cached);
+    if (!force && cached && ageMs < repoAudienceCacheTtlMs) {
+      ranges.push({
+        range,
+        state: "fresh",
+        users: cached.users.length,
+        generatedAt: cached.generatedAt,
+      });
+      continue;
+    }
+    const lock = await acquireBuildLock(env, `${key}:backfill`);
+    if (!lock) {
+      ranges.push({
+        range,
+        state: "busy",
+        users: cached?.users.length ?? 0,
+        generatedAt: cached?.generatedAt ?? new Date().toISOString(),
+      });
+      continue;
+    }
+    try {
+      const payload = await buildRepoAudience(owner, repo, range, request, env, requestToken);
+      await writeRepoAudience(env, key, payload);
+      ranges.push({
+        range,
+        state: "rebuilt",
+        users: payload.users.length,
+        generatedAt: payload.generatedAt,
+      });
+    } finally {
+      await lock.release();
+    }
+  }
+  return jsonResponse(
+    {
+      fullName,
+      ranges,
+      quota: {
+        source: requestToken.quotaSource,
+        account: requestToken.quotaAccount,
+      },
+      message: "bounded stargazer trust caches backfilled with GitHub App quota",
+    },
+    200,
+    { "cache-control": "no-store" },
+  );
+}
+
 function repoDetailCacheKey(owner: string, repo: string): string {
   return `repo-detail:v4:${slugOwner(owner)}/${repo.toLowerCase()}`;
 }
@@ -4139,6 +5761,23 @@ async function summarizeReleaseDelta(
   };
 }
 
+type ContributorTrustSignal = UserTrustSignal;
+
+async function cachedContributorTrustSignals(
+  env: Env,
+  contributors: Array<InferOutput<typeof gitHubContributorSchema>>,
+): Promise<Map<string, ContributorTrustSignal>> {
+  const logins = Array.from(
+    new Set(
+      contributors
+        .map((contributor) => contributor.login)
+        .filter((login): login is string => Boolean(login))
+        .map(slugOwner),
+    ),
+  );
+  return cachedUserTrustSignals(env, logins);
+}
+
 async function buildRepoDetail(
   owner: string,
   repoName: string,
@@ -4295,7 +5934,10 @@ async function buildRepoDetail(
   project.ciUrl = ci.ciUrl;
   project.ciRunDate = ci.ciRunDate;
   project.ciState = ci.ciState;
-  const releaseSummary = await releaseSummaryState(project, env);
+  const [releaseSummary, contributorTrustSignals] = await Promise.all([
+    releaseSummaryState(project, env),
+    cachedContributorTrustSignals(env, contributors),
+  ]);
 
   const generatedAt = new Date().toISOString();
   return {
@@ -4329,12 +5971,17 @@ async function buildRepoDetail(
         publishedAt: release.published_at,
         prerelease: release.prerelease ?? false,
       })),
-    contributors: contributors.map((contributor) => ({
-      login: contributor.login ?? "anonymous",
-      avatarUrl: contributor.avatar_url ?? null,
-      url: contributor.html_url ?? null,
-      commits: contributor.contributions,
-    })),
+    contributors: contributors.map((contributor) => {
+      const login = contributor.login ?? "anonymous";
+      const trustSignal = contributorTrustSignals.get(slugOwner(login));
+      return {
+        login,
+        avatarUrl: contributor.avatar_url ?? null,
+        url: contributor.html_url ?? null,
+        commits: contributor.contributions,
+        ...(trustSignal ? { trustScore: trustSignal.score, trustTier: trustSignal.tier } : {}),
+      };
+    }),
     commitActivity: (commitActivity.data ?? []).map((week) => ({
       week: new Date(week.week * 1000).toISOString(),
       total: week.total,
@@ -4524,20 +6171,27 @@ async function repoDetailResponse(
     if (releaseSummaryNeedsRefresh(cached, env)) {
       context.waitUntil(refreshReleaseSummary(key, owner, repo, cached, request, env));
     }
-    return jsonResponse(cached, 202, { "cache-control": "no-store" });
+    return jsonResponse(await withRepoDetailContributorTrustProfiles(cached, env), 202, {
+      "cache-control": "no-store",
+    });
   }
   if (cached && ageMs < repoDetailCacheTtlMs && cached.cache.state !== "warming") {
     if (releaseSummaryNeedsRefresh(cached, env)) {
       context.waitUntil(refreshReleaseSummary(key, owner, repo, cached, request, env));
     }
-    return jsonResponse(cached);
+    return jsonResponse(await withRepoDetailContributorTrustProfiles(cached, env));
   }
   if (cached && ageMs <= maxDisplayStaleMs) {
     context.waitUntil(refreshRepoDetail(key, owner, repo, request, env).catch(() => undefined));
     if (releaseSummaryNeedsRefresh(cached, env)) {
       context.waitUntil(refreshReleaseSummary(key, owner, repo, cached, request, env));
     }
-    return jsonResponse(withRepoDetailState(cached, "stale", "refreshing repository statistics"));
+    return jsonResponse(
+      await withRepoDetailContributorTrustProfiles(
+        withRepoDetailState(cached, "stale", "refreshing repository statistics"),
+        env,
+      ),
+    );
   }
 
   try {
@@ -4546,9 +6200,13 @@ async function repoDetailResponse(
     if (releaseSummaryNeedsRefresh(payload, env)) {
       context.waitUntil(refreshReleaseSummary(key, owner, repo, payload, request, env));
     }
-    return jsonResponse(payload, payload.cache.state === "warming" ? 202 : 200, {
-      "cache-control": payload.cache.state === "warming" ? "no-store" : "public, max-age=60",
-    });
+    return jsonResponse(
+      await withRepoDetailContributorTrustProfiles(payload, env),
+      payload.cache.state === "warming" ? 202 : 200,
+      {
+        "cache-control": payload.cache.state === "warming" ? "no-store" : "public, max-age=60",
+      },
+    );
   } catch (error) {
     return jsonResponse(
       {
@@ -4924,6 +6582,7 @@ async function cachedDiscoverInitialData(env: Env, url: URL): Promise<InitialPag
 }
 
 async function dashboardCacheKeyForPage(
+  request: Request,
   url: URL,
   env: Env,
   primaryOwner: string | null,
@@ -4951,22 +6610,31 @@ async function dashboardCacheKeyForPage(
   if (!primaryOwner && extraOwnerSlugs.length === 0 && includeRepos.length === 0) {
     return null;
   }
+  const ownerSlugs =
+    primaryOwner && !hiddenProfileOwners.has(primaryOwner)
+      ? [primaryOwner, ...extraOwnerSlugs]
+      : extraOwnerSlugs;
+  const tokenSources = { owners: ownerSlugs, repos: includeRepos };
+  const token = await bestInstallationToken(request, env, tokenSources).catch(() => null);
+  const includeReleaseData = await dashboardReleaseDataAllowed(request, env, tokenSources, token);
   return dashboardCacheKey({
     owner: primaryOwner ?? "custom",
     owners: extraOwnerSlugs,
     repos: includeRepos,
     salt: profile?.updatedAt,
     ...options,
+    includeReleaseData,
     schemaVersion: dashboardSchemaVersion,
   });
 }
 
 async function cachedDashboardInitialData(
+  request: Request,
   env: Env,
   url: URL,
   primaryOwner: string | null,
 ): Promise<InitialPageData | null> {
-  const key = await dashboardCacheKeyForPage(url, env, primaryOwner);
+  const key = await dashboardCacheKeyForPage(request, url, env, primaryOwner);
   const cached = key ? await readCached(env, key) : null;
   if (!cached || !canDisplayCached(cached) || cached.cache?.state === "error") return null;
   const state =
@@ -4978,15 +6646,55 @@ async function cachedDashboardInitialData(
   return { route: "dashboard", payload: withCacheState(cached, state) };
 }
 
-async function dashboardEventParts(url: URL, env: Env): Promise<{ key: string } | null> {
+async function dashboardEventParts(request: Request, env: Env): Promise<{ key: string } | null> {
+  const url = new URL(request.url);
   const rawOwner =
     url.pathname
       .replace(/^\/api\//, "")
       .replace(/\/events$/, "")
       .split("/")[0] ?? "";
   const primaryOwner = rawOwner === "dashboard" ? null : slugOwner(rawOwner);
-  const key = await dashboardCacheKeyForPage(url, env, primaryOwner);
-  return key ? { key } : null;
+  if (primaryOwner !== null && !validOwnerSlug(primaryOwner)) {
+    return null;
+  }
+  const options = optionsFromUrl(url);
+  const profile = primaryOwner ? await readProfile(env, primaryOwner) : null;
+  const hiddenProfileOwners = new Set(profile?.hiddenOwners ?? []);
+  const hiddenProfileRepos = new Set(profile?.hiddenRepos ?? []);
+  const extraOwnerSlugs = uniqueSorted([
+    ...(profile?.includeOwners ?? []),
+    ...ownerListFromUrl(url, primaryOwner ?? undefined),
+  ]).filter((owner) => owner !== primaryOwner && !hiddenProfileOwners.has(owner));
+  const includeRepos = uniqueSorted([
+    ...(profile?.includeRepos ?? []),
+    ...repoListFromUrl(url),
+  ]).filter(
+    (repo) => !hiddenProfileOwners.has(repo.split("/")[0] ?? "") && !hiddenProfileRepos.has(repo),
+  );
+  if (extraOwnerSlugs.length + includeRepos.length > maxCustomSources) {
+    return null;
+  }
+  if (!primaryOwner && extraOwnerSlugs.length === 0 && includeRepos.length === 0) {
+    return null;
+  }
+  const ownerSlugs =
+    primaryOwner && !hiddenProfileOwners.has(primaryOwner)
+      ? [primaryOwner, ...extraOwnerSlugs]
+      : extraOwnerSlugs;
+  const tokenSources = { owners: ownerSlugs, repos: includeRepos };
+  const token = await bestInstallationToken(request, env, tokenSources).catch(() => null);
+  const includeReleaseData = await dashboardReleaseDataAllowed(request, env, tokenSources, token);
+  return {
+    key: dashboardCacheKey({
+      owner: primaryOwner ?? "custom",
+      owners: extraOwnerSlugs,
+      repos: includeRepos,
+      salt: profile?.updatedAt,
+      ...options,
+      includeReleaseData,
+      schemaVersion: dashboardSchemaVersion,
+    }),
+  };
 }
 
 function sleep(ms: number): Promise<void> {
@@ -5003,8 +6711,7 @@ function dashboardStreamState(
 }
 
 async function ownerEventsResponse(request: Request, env: Env): Promise<Response> {
-  const url = new URL(request.url);
-  const parts = await dashboardEventParts(url, env);
+  const parts = await dashboardEventParts(request, env);
   if (!parts) {
     return jsonResponse({ error: "invalid dashboard event stream" }, 400, {
       "cache-control": "no-store",
@@ -5142,6 +6849,7 @@ async function rebuild(dashboard: DashboardRequest, env: Env): Promise<Dashboard
       initialProjects: progressProjects,
       skipRepos: [...scannedRepos],
       token: dashboard.token ?? env.GITHUB_TOKEN,
+      includeReleaseData: dashboard.includeReleaseData,
       quotaSource:
         dashboard.quotaSource ?? (dashboard.token || env.GITHUB_TOKEN ? "shared" : "anonymous"),
       quotaAccount: dashboard.quotaAccount ?? null,
@@ -5217,6 +6925,7 @@ function unresolvedDashboardRequest(
   profile: DashboardProfile | null,
   key: string,
   url: URL,
+  includeReleaseData: boolean,
   token?: RequestToken | null,
 ): DashboardRequest {
   return dashboardRequest(
@@ -5225,6 +6934,7 @@ function unresolvedDashboardRequest(
     profile,
     key,
     url,
+    includeReleaseData,
     token,
   );
 }
@@ -5409,30 +7119,34 @@ async function ownerResponse(
     primaryOwner && !hiddenProfileOwners.has(primaryOwner)
       ? [primaryOwner, ...extraOwnerSlugs]
       : extraOwnerSlugs;
+  const tokenSources = { owners: ownerSlugs, repos: includeRepos };
+  const requestToken = () => bestInstallationToken(request, env, tokenSources);
+  const token = await requestToken().catch(() => null);
+  const includeReleaseData = await dashboardReleaseDataAllowed(request, env, tokenSources, token);
   const key = dashboardCacheKey({
     owner: primaryOwner ?? "custom",
     owners: extraOwnerSlugs,
     repos: includeRepos,
     salt: profile?.updatedAt,
     ...options,
+    includeReleaseData,
     schemaVersion: dashboardSchemaVersion,
   });
   const cached = await readCached(env, key);
   const ageMs = cacheAgeMs(cached);
   const displayCached = canDisplayCached(cached);
-  const tokenSources = { owners: ownerSlugs, repos: includeRepos };
-  const requestToken = () => bestInstallationToken(request, env, tokenSources);
 
   if (displayCached && cached.cache?.state === "error") {
+    const dashboard = cachedDashboardRequest(
+      cached,
+      includeRepos,
+      key,
+      url,
+      includeReleaseData,
+      token,
+    );
     context.waitUntil(
-      requestToken()
-        .catch(() => null)
-        .then((token) => {
-          const dashboard = cachedDashboardRequest(cached, includeRepos, key, url, token);
-          return rebuildWithBuildLock(dashboard, env).catch((error) =>
-            cacheBuildError(dashboard, env, error),
-          );
-        }),
+      rebuildWithBuildLock(dashboard, env).catch((error) => cacheBuildError(dashboard, env, error)),
     );
     return jsonResponse(cached, errorStatus(cached.cache.message ?? ""), {
       "cache-control": "no-store",
@@ -5440,25 +7154,25 @@ async function ownerResponse(
   }
 
   if (displayCached && cached.cache?.progress?.done !== false && ageMs < fullTtlMs) {
-    return jsonResponse(withCacheState(cached, "fresh"));
+    return jsonResponse(withCacheState(cached, "fresh"), 200, authDependentDashboardHeaders(env));
   }
 
   if (displayCached) {
-    context.waitUntil(
-      requestToken()
-        .catch(() => null)
-        .then((token) => {
-          const dashboard = cachedDashboardRequest(cached, includeRepos, key, url, token);
-          return continueProgressiveBuild(dashboard, env).catch(() => undefined);
-        }),
+    const dashboard = cachedDashboardRequest(
+      cached,
+      includeRepos,
+      key,
+      url,
+      includeReleaseData,
+      token,
     );
+    context.waitUntil(continueProgressiveBuild(dashboard, env).catch(() => undefined));
     const state = cached.cache?.progress?.done === false ? "partial" : "stale";
     return jsonResponse(withCacheState(cached, state), 200, {
       "cache-control": "no-store",
     });
   }
 
-  const token = await requestToken().catch(() => null);
   let owners: Owner[] | null;
   try {
     owners = await resolveOwners(
@@ -5475,6 +7189,7 @@ async function ownerResponse(
       profile,
       key,
       url,
+      includeReleaseData,
       token,
     );
     const payload = errorPayload(dashboard, env, dashboardErrorMessage(error));
@@ -5487,7 +7202,15 @@ async function ownerResponse(
     });
   }
 
-  const dashboard = dashboardRequest(owners, includeRepos, profile, key, url, token);
+  const dashboard = dashboardRequest(
+    owners,
+    includeRepos,
+    profile,
+    key,
+    url,
+    includeReleaseData,
+    token,
+  );
   const build = rebuildWithBuildLock(dashboard, env);
   try {
     const payload = await Promise.race([
@@ -5528,7 +7251,7 @@ async function ownerResponse(
         "cache-control": "no-store",
       });
     }
-    return jsonResponse(payload);
+    return jsonResponse(payload, 200, authDependentDashboardHeaders(env));
   } catch (error) {
     const payload = errorPayload(dashboard, env, dashboardErrorMessage(error));
     await writeCached(env, key, payload, 5 * 60);
@@ -5541,9 +7264,18 @@ function cachedDashboardRequest(
   includeRepos: string[],
   key: string,
   url: URL,
+  includeReleaseData: boolean,
   token?: RequestToken | null,
 ): DashboardRequest {
-  return dashboardRequest(payload.owners, includeRepos, payload.profile ?? null, key, url, token);
+  return dashboardRequest(
+    payload.owners,
+    includeRepos,
+    payload.profile ?? null,
+    key,
+    url,
+    includeReleaseData,
+    token,
+  );
 }
 
 function dashboardRequest(
@@ -5552,6 +7284,7 @@ function dashboardRequest(
   profile: DashboardProfile | null,
   key: string,
   url: URL,
+  includeReleaseData: boolean,
   token?: RequestToken | null,
 ): DashboardRequest {
   return {
@@ -5561,6 +7294,7 @@ function dashboardRequest(
     subtitle: dashboardSubtitle(owners, includeRepos),
     key,
     url,
+    includeReleaseData,
     ...(token
       ? {
           token: token.token,
@@ -5635,7 +7369,9 @@ export default {
     const profileWrite =
       url.pathname.startsWith("/api/profile/") &&
       (request.method === "POST" || request.method === "DELETE");
-    if (request.method !== "GET" && !isHead && !profileWrite) {
+    const audienceBackfillWrite =
+      isRepoAudienceBackfillApiPath(url.pathname) && request.method === "POST";
+    if (request.method !== "GET" && !isHead && !profileWrite && !audienceBackfillWrite) {
       return jsonResponse({ error: "method not allowed" }, 405, { allow: "GET" });
     }
     const response = await routeRequest(request, env, context, url);
@@ -5662,6 +7398,12 @@ async function routeRequest(
       label.startsWith("@") || label.includes("/") || !validOwnerSlug(label) ? label : `@${label}`;
     return socialImage(await socialCardForLabel(title, request, env, context));
   }
+  if (url.pathname === "/openapi.json" || url.pathname === "/api/openapi.json") {
+    return jsonResponse(openApiSpec(url.origin));
+  }
+  if (url.pathname === "/api/swagger.json") {
+    return jsonResponse(openApiSpec(url.origin));
+  }
   if (url.pathname === "/api/me") {
     return meResponse(request, env);
   }
@@ -5683,14 +7425,26 @@ async function routeRequest(
   if (isRepoActivityApiPath(url.pathname)) {
     return repoActivityResponse(request, env, context);
   }
+  if (isTrustProfileApiPath(url.pathname)) {
+    return trustProfileResponse(request, env, context);
+  }
+  if (isRepoAudienceBackfillApiPath(url.pathname)) {
+    return repoAudienceBackfillResponse(request, env);
+  }
+  if (isRepoAudienceApiPath(url.pathname)) {
+    return repoAudienceResponse(request, env, context);
+  }
   if (isRepoDetailApiPath(url.pathname)) {
     return repoDetailResponse(request, env, context);
   }
-  if (url.pathname.startsWith("/api/") && url.pathname.endsWith("/events")) {
+  if (isOwnerEventsApiPath(url.pathname)) {
     return ownerEventsResponse(request, env);
   }
-  if (url.pathname.startsWith("/api/")) {
+  if (isOwnerApiPath(url.pathname)) {
     return ownerResponse(request, env, context);
+  }
+  if (url.pathname.startsWith("/api/")) {
+    return jsonResponse({ error: "not found" }, 404, { "cache-control": "no-store" });
   }
   return assetResponse(request, env);
 }

--- a/worker/schemas.ts
+++ b/worker/schemas.ts
@@ -104,6 +104,62 @@ export const gitHubRepositorySchema = v.looseObject({
   updated_at: v.nullable(v.string()),
 });
 
+export const gitHubStargazerSchema = v.looseObject({
+  starred_at: v.nullable(v.string()),
+  user: v.looseObject({
+    login: v.string(),
+    avatar_url: v.string(),
+    html_url: v.string(),
+  }),
+});
+
+export const gitHubStargazerListSchema = v.array(gitHubStargazerSchema);
+
+export const gitHubUserProfileSchema = v.looseObject({
+  login: v.string(),
+  avatar_url: v.string(),
+  html_url: v.string(),
+  type: v.optional(v.string()),
+  name: v.nullable(v.string()),
+  company: v.nullable(v.string()),
+  bio: v.nullable(v.string()),
+  location: v.nullable(v.string()),
+  blog: v.nullable(v.string()),
+  twitter_username: v.nullable(v.string()),
+  followers: v.number(),
+  following: v.number(),
+  public_repos: v.number(),
+  public_gists: v.number(),
+  created_at: v.nullable(v.string()),
+  updated_at: v.nullable(v.string()),
+});
+
+export const gitHubUserOrganizationSchema = v.looseObject({
+  login: v.string(),
+  avatar_url: v.string(),
+  description: v.nullable(v.string()),
+});
+
+export const gitHubUserOrganizationListSchema = v.array(gitHubUserOrganizationSchema);
+
+export const gitHubUserRepositorySchema = v.looseObject({
+  full_name: v.string(),
+  html_url: v.string(),
+  description: v.nullable(v.string()),
+  language: v.nullable(v.string()),
+  stargazers_count: v.number(),
+  forks_count: v.number(),
+  private: v.optional(v.boolean()),
+  visibility: v.optional(v.string()),
+  fork: v.boolean(),
+  archived: v.boolean(),
+  topics: v.optional(v.array(v.string())),
+  pushed_at: v.nullable(v.string()),
+  updated_at: v.nullable(v.string()),
+});
+
+export const gitHubUserRepositoryListSchema = v.array(gitHubUserRepositorySchema);
+
 export const gitHubReleaseSchema = v.looseObject({
   tag_name: v.string(),
   name: v.nullable(v.string()),
@@ -223,7 +279,11 @@ export type GitHubInstallationToken = v.InferOutput<typeof gitHubInstallationTok
 export type GitHubRepository = v.InferOutput<typeof gitHubRepositorySchema>;
 export type GitHubRelease = v.InferOutput<typeof gitHubReleaseSchema>;
 export type GitHubSearchRepository = v.InferOutput<typeof gitHubSearchRepositorySchema>;
+export type GitHubStargazer = v.InferOutput<typeof gitHubStargazerSchema>;
 export type GitHubPublicEvent = v.InferOutput<typeof gitHubPublicEventSchema>;
+export type GitHubUserOrganization = v.InferOutput<typeof gitHubUserOrganizationSchema>;
+export type GitHubUserProfile = v.InferOutput<typeof gitHubUserProfileSchema>;
+export type GitHubUserRepository = v.InferOutput<typeof gitHubUserRepositorySchema>;
 
 export function parseGitHubResponse<TSchema extends v.GenericSchema>(
   schema: TSchema,


### PR DESCRIPTION
## Summary
- add cached trust profiles and repository audience analysis for recent stargazers
- keep unsynced public dashboards metadata-only so shared quota does not hydrate the whole universe
- surface trust scores in owner tabs, repo audience views, and contributor pills
- document public trust/audience APIs for agent PR triage

## Proof
- codex review --base origin/main
- npm run check:static