### PR TITLE
[codex] add my dashboard shortcut

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Added a logged-in account menu and command palette shortcut for opening your own dashboard.
 - Embed cached public dashboard and repository payloads in served app shells so warm routes render without an initial loading panel.
 - Added OpenAPI/Swagger JSON endpoints for the public trust and audience APIs.
 - Refined trust UI labels, audience percentage summaries, contributor score pills, and external-link markers.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Matched the trust tab's content spacing to the overview tab.
 - Added a logged-in account menu and command palette shortcut for opening your own dashboard.
 - Embed cached public dashboard and repository payloads in served app shells so warm routes render without an initial loading panel.
 - Added OpenAPI/Swagger JSON endpoints for the public trust and audience APIs.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Simplified owner trust navigation by removing the overview tab buttons and trimming the trust snapshot copy.
 - Matched the trust tab's content spacing to the overview tab.
 - Added a logged-in account menu and command palette shortcut for opening your own dashboard.
 - Embed cached public dashboard and repository payloads in served app shells so warm routes render without an initial loading panel.

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -2603,27 +2603,6 @@
       {/if}
     </section>
   {:else}
-  {#if showTrustProfile}
-    <nav class="owner-tabs" aria-label="Owner page sections">
-      <button
-        class:active={ownerTab === "overview"}
-        type="button"
-        aria-pressed={ownerTab === "overview"}
-        onclick={() => setOwnerTab("overview")}
-      >
-        overview
-      </button>
-      <button
-        class:active={ownerTab === "trust"}
-        type="button"
-        aria-pressed={ownerTab === "trust"}
-        onclick={() => setOwnerTab("trust")}
-      >
-        {ownerSignalTabLabel()}
-      </button>
-    </nav>
-  {/if}
-
   {#if showTrustProfile && ownerTab === "overview"}
     <section class="trust-snapshot" aria-label={`${ownerSignalLabel()} summary`}>
       {#if trustProfileLoading}
@@ -2652,8 +2631,7 @@
           <span>{trustProfile.type === "org" ? "footprint" : "builder"}</span>
           <strong>{numberFormat.format(trustProfile.stats.activeRepositories)} active repos</strong>
         </div>
-        <p>{audienceReasonText(trustProfile.reasons)}</p>
-        <button type="button" onclick={() => setOwnerTab("trust")}>view factors</button>
+        <button type="button" onclick={() => setOwnerTab("trust")}>factors</button>
       {:else}
         <span class="panel-kicker">{ownerSignalTabLabel()}</span>
         <strong>pending</strong>
@@ -2669,9 +2647,12 @@
           <span class="panel-kicker">{ownerSignalTabLabel()}</span>
           <h2>{trustProfile ? `${trustProfile.score}` : "loading"}</h2>
         </div>
-        {#if trustProfile}
-          <span class={`audience-tier tier-${trustProfile.tier}`}>{trustProfile.tier}</span>
-        {/if}
+        <div class="trust-panel-actions">
+          <button type="button" onclick={() => setOwnerTab("overview")}>overview</button>
+          {#if trustProfile}
+            <span class={`audience-tier tier-${trustProfile.tier}`}>{trustProfile.tier}</span>
+          {/if}
+        </div>
       </div>
 
       {#if trustProfileLoading}

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -599,7 +599,11 @@
   }
 
   function openOwner(owner: string): void {
-    location.assign(`/${encodeURIComponent(owner.replace(/^@/, ""))}`);
+    location.assign(ownerDashboardPath(owner));
+  }
+
+  function openSignedInUserDashboard(): void {
+    if (auth?.user) openOwner(auth.user.login);
   }
 
   function toggleSet(set: Set<string>, key: string, visible: boolean): Set<string> {
@@ -1707,6 +1711,19 @@
       keywords: ["owner", "dashboard", owner],
       onRun: () => openOwner(owner),
     }));
+    const authLogin = authPayload?.user?.login ?? null;
+    const accountDashboardCommands: CommandAction[] = authLogin
+      ? [
+          {
+            actionId: "account:dashboard",
+            title: "Open my dashboard",
+            subTitle: `@${authLogin}`,
+            group: "Account",
+            keywords: ["me", "account", "dashboard", authLogin],
+            onRun: () => openOwner(authLogin),
+          },
+        ]
+      : [];
 
     return [
       ...typedCommands,
@@ -1804,6 +1821,7 @@
         : []),
       ...(authPayload?.user
         ? [
+            ...accountDashboardCommands,
             ...(authPayload.installNeeded
               ? [
                   {
@@ -2018,6 +2036,9 @@
             <span class="account-caret" aria-hidden="true"></span>
           </DropdownMenu.Trigger>
           <DropdownMenu.Content class="account-dropdown" align="end" sideOffset={8} loop>
+            <DropdownMenu.Item class="menu-action" onSelect={openSignedInUserDashboard}>
+              My Dashboard
+            </DropdownMenu.Item>
             {#if !repoRoute}
               <DropdownMenu.Item class="menu-action" onSelect={() => (settingsOpen = !settingsOpen)}>
                 Settings

--- a/src/styles.css
+++ b/src/styles.css
@@ -543,7 +543,6 @@ h1 {
 .activity-panel {
   display: grid;
   gap: 12px;
-  margin: -8px 0 22px;
   padding: 20px;
   border: 1px solid var(--line);
   border-radius: var(--radius);
@@ -551,6 +550,14 @@ h1 {
     linear-gradient(90deg, rgba(156, 255, 87, 0.055), transparent 42%),
     color-mix(in srgb, var(--panel) 78%, transparent);
   box-shadow: var(--shadow);
+}
+
+.trust-panel {
+  margin: -2px 0 22px;
+}
+
+.activity-panel {
+  margin: -8px 0 22px;
 }
 
 .activity-panel .panel-heading {

--- a/src/styles.css
+++ b/src/styles.css
@@ -461,32 +461,12 @@ h1 {
 
 /* Trust profile and owner activity */
 
-.owner-tabs {
-  display: flex;
-  gap: 8px;
-  margin: -8px 0 12px;
-}
-
-.owner-tabs button {
-  min-height: 34px;
-  border-color: var(--line);
-  background: rgba(8, 9, 8, 0.45);
-  color: var(--muted);
-  font-size: 13px;
-}
-
-.owner-tabs button.active {
-  border-color: color-mix(in srgb, var(--green) 58%, var(--line-strong));
-  background: rgba(156, 255, 87, 0.075);
-  color: var(--text);
-}
-
 .trust-snapshot {
   display: grid;
-  grid-template-columns: 120px repeat(3, minmax(0, 1fr)) minmax(180px, 1.3fr) auto;
+  grid-template-columns: 120px repeat(3, minmax(0, 1fr)) auto;
   align-items: center;
   gap: 10px;
-  margin: -2px 0 18px;
+  margin: 0 0 18px;
   border: 1px solid var(--line);
   border-radius: var(--radius);
   padding: 14px 16px;
@@ -524,16 +504,6 @@ h1 {
   line-height: 1;
 }
 
-.trust-snapshot p {
-  min-width: 0;
-  margin: 0;
-  overflow: hidden;
-  color: var(--text);
-  font-size: 13px;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
 .trust-snapshot button {
   min-height: 32px;
   white-space: nowrap;
@@ -553,11 +523,26 @@ h1 {
 }
 
 .trust-panel {
-  margin: -2px 0 22px;
+  margin: 0 0 22px;
 }
 
 .activity-panel {
   margin: -8px 0 22px;
+}
+
+.trust-panel-actions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+.trust-panel-actions button {
+  min-height: 32px;
+  padding: 0 11px;
+  background: color-mix(in srgb, var(--bg) 52%, transparent);
+  color: var(--muted);
+  font-size: 13px;
 }
 
 .activity-panel .panel-heading {
@@ -2676,7 +2661,6 @@ body.dev-mode .table-head .since-heading .label-compact {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 
-  .owner-tabs,
   .trust-snapshot {
     margin-right: 0;
     margin-left: 0;
@@ -2686,7 +2670,6 @@ body.dev-mode .table-head .since-heading .label-compact {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 
-  .trust-snapshot p,
   .trust-snapshot button {
     grid-column: 1 / -1;
   }


### PR DESCRIPTION
## Summary
- add a My Dashboard item to the logged-in account menu
- add an Open my dashboard command palette action
- route dashboard jumps through the shared owner dashboard path helper
- match owner trust detail spacing to the overview snapshot
- simplify trust navigation by removing the top overview/trust tabs, trimming the overview snapshot copy, and keeping a compact factors/overview drill-in flow
- document the user-facing changes in the changelog

## Validation
- npm run check:static
- codex-review --parallel-tests "npm run check:static" clean: no accepted/actionable findings reported