### PR TITLE
feat: add manual dashboard refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Improved the mobile dashboard layout with scrollable filter/sort rails, compact repository cards, and tighter header/search controls.
 - Added a manual dashboard refresh button that refreshes cheap issue and PR counts first, then continues release hydration in the background.
 - Replaced the generic `</>` favicon with a green release-tag silhouette so the tab icon reads as ReleaseBar at 16px and aligns with the release/version brand.
 - Added browser-side dashboard timing beacons for cached boot renders, API fetches, and streamed updates so client latency can be compared with Worker background tail duration.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Added a manual dashboard refresh button that refreshes cheap issue and PR counts first, then continues release hydration in the background.
 - Replaced the generic `</>` favicon with a green release-tag silhouette so the tab icon reads as ReleaseBar at 16px and aligns with the release/version brand.
 - Added browser-side dashboard timing beacons for cached boot renders, API fetches, and streamed updates so client latency can be compared with Worker background tail duration.
 - Logged dashboard sync, progressive refresh, stream delivery, and discover hydration phases so fast visible data and slower GitHub scans can be studied separately.

--- a/scripts/lib/dashboard.test.ts
+++ b/scripts/lib/dashboard.test.ts
@@ -3989,6 +3989,289 @@ test("worker keeps repository detail when work trend search is rate limited", as
   }
 });
 
+test("worker manual dashboard refresh returns metadata before release hydration", async () => {
+  const originalFetch = globalThis.fetch;
+  const waits: Array<Promise<unknown>> = [];
+  const repoNode = (issues: number, pullRequests: number) => ({
+    owner: { login: "owner", __typename: "User" },
+    name: "repo",
+    nameWithOwner: "owner/repo",
+    description: "Manual refresh repo",
+    url: "https://github.com/owner/repo",
+    defaultBranchRef: { name: "main" },
+    primaryLanguage: { name: "TypeScript" },
+    repositoryTopics: { nodes: [] },
+    stargazerCount: 42,
+    forkCount: 2,
+    issues: { totalCount: issues },
+    pullRequests: { totalCount: pullRequests },
+    isArchived: false,
+    isFork: false,
+    isPrivate: false,
+    pushedAt: "2026-05-15T00:00:00Z",
+    updatedAt: "2026-05-15T00:00:00Z",
+    releases: {
+      nodes: [
+        {
+          tagName: "v1.0.0",
+          name: null,
+          url: "https://github.com/owner/repo/releases/tag/v1.0.0",
+          isDraft: false,
+          publishedAt: "2026-05-01T00:00:00Z",
+        },
+      ],
+    },
+  });
+  globalThis.fetch = async (input) => {
+    const url = new URL(String(input));
+    if (url.pathname === "/users/owner") {
+      return Response.json({
+        login: "owner",
+        type: "User",
+        avatar_url: "https://avatars.githubusercontent.com/u/1",
+        html_url: "https://github.com/owner",
+      });
+    }
+    if (url.pathname === "/graphql") {
+      return Response.json({
+        data: {
+          repositoryOwner: {
+            __typename: "User",
+            repositories: {
+              pageInfo: { hasNextPage: false, endCursor: null },
+              nodes: [repoNode(9, 4)],
+            },
+          },
+        },
+      });
+    }
+    if (url.pathname === "/repos/owner/repo/commits/main") {
+      return Response.json({
+        sha: "abcdef123456",
+        commit: { committer: { date: "2026-05-15T00:00:00Z" } },
+      });
+    }
+    if (url.pathname === "/repos/owner/repo/compare/v1.0.0...main") {
+      return Response.json({
+        total_commits: 3,
+        html_url: "https://github.com/owner/repo/compare/v1.0.0...main",
+      });
+    }
+    if (url.pathname === "/repos/owner/repo/commits/abcdef123456/check-runs") {
+      return Response.json({ check_runs: [] });
+    }
+    throw new Error(`unexpected fetch ${url.pathname}`);
+  };
+  const env = { DASHBOARD_CACHE: kvStore(), GITHUB_TOKEN: "shared-token" };
+  try {
+    const response = await worker.fetch(
+      new Request("https://release.bar/api/owner", { method: "POST" }),
+      env,
+      { waitUntil: (promise) => waits.push(promise) },
+    );
+    assert.equal(response.status, 202);
+    const body = (await response.json()) as DashboardPayload;
+    assert.equal(body.cache?.state, "partial");
+    assert.equal(body.cache?.progress?.done, false);
+    assert.match(body.cache?.message ?? "", /issue and PR counts refreshed/);
+    assert.equal(body.projects[0]?.openIssues, 9);
+    assert.equal(body.projects[0]?.openPullRequests, 4);
+    assert.equal(body.projects[0]?.version, "repo search");
+
+    const repeated = await worker.fetch(
+      new Request("https://release.bar/api/owner", { method: "POST" }),
+      env,
+      { waitUntil: (promise) => waits.push(promise) },
+    );
+    assert.equal(repeated.status, 202);
+    const repeatedBody = (await repeated.json()) as DashboardPayload;
+    assert.match(repeatedBody.cache?.message ?? "", /manual refresh recently started/);
+    assert.equal(repeatedBody.projects[0]?.openIssues, 9);
+
+    await Promise.all(waits);
+    const cached = await worker.fetch(new Request("https://release.bar/api/owner"), env, {
+      waitUntil: () => undefined,
+    });
+    const hydrated = (await cached.json()) as DashboardPayload;
+    assert.equal(hydrated.cache?.state, "fresh");
+    assert.equal(hydrated.projects[0]?.version, "v1.0.0");
+    assert.equal(hydrated.projects[0]?.commitsSinceRelease, 3);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("worker manual dashboard refresh returns structured GitHub errors", async () => {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (input) => {
+    const url = new URL(String(input));
+    if (url.pathname === "/users/owner") {
+      return Response.json({
+        login: "owner",
+        type: "User",
+        avatar_url: "https://avatars.githubusercontent.com/u/1",
+        html_url: "https://github.com/owner",
+      });
+    }
+    if (url.pathname === "/graphql") {
+      return Response.json(
+        { message: "API rate limit exceeded" },
+        {
+          status: 403,
+          headers: { "x-ratelimit-remaining": "0", "retry-after": "30" },
+        },
+      );
+    }
+    throw new Error(`unexpected fetch ${url.pathname}`);
+  };
+  const env = { DASHBOARD_CACHE: kvStore(), GITHUB_TOKEN: "shared-token" };
+  try {
+    const response = await worker.fetch(
+      new Request("https://release.bar/api/owner", { method: "POST" }),
+      env,
+      { waitUntil: () => undefined },
+    );
+    assert.equal(response.status, 429);
+    assert.equal(response.headers.get("retry-after"), "30");
+    const body = (await response.json()) as DashboardPayload;
+    assert.equal(body.cache?.state, "error");
+    assert.match(body.cache?.message ?? "", /GitHub shared API quota is exhausted/);
+
+    const key = dashboardCacheKey({ owner: "owner", includeUnreleased: true, schemaVersion: 5 });
+    const dashboard = testDashboard("owner", [testProject({ owner: "owner", name: "repo" })]);
+    dashboard.generatedAt = new Date().toISOString();
+    if (dashboard.cache && dashboard.options) {
+      dashboard.cache.generatedAt = dashboard.generatedAt;
+      dashboard.options.includeUnreleased = true;
+    }
+    const cache = kvStore({ [key]: JSON.stringify(dashboard) });
+    const cachedResponse = await worker.fetch(
+      new Request("https://release.bar/api/owner", { method: "POST" }),
+      { DASHBOARD_CACHE: cache, GITHUB_TOKEN: "shared-token" },
+      { waitUntil: () => undefined },
+    );
+    assert.equal(cachedResponse.status, 429);
+    const cached = JSON.parse((await cache.get(key)) ?? "{}") as DashboardPayload;
+    assert.equal(cached.cache?.state, "fresh");
+    assert.equal(cached.projects.length, 1);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("worker manual dashboard refresh preserves released-only cache while rebuilding", async () => {
+  const originalFetch = globalThis.fetch;
+  const waits: Array<Promise<unknown>> = [];
+  globalThis.fetch = async (input) => {
+    const url = new URL(String(input));
+    if (url.pathname === "/graphql") {
+      return Response.json({
+        data: {
+          repositoryOwner: {
+            __typename: "User",
+            repositories: {
+              pageInfo: { hasNextPage: false, endCursor: null },
+              nodes: [
+                {
+                  owner: { login: "owner", __typename: "User" },
+                  name: "repo",
+                  nameWithOwner: "owner/repo",
+                  description: "Released repo",
+                  url: "https://github.com/owner/repo",
+                  defaultBranchRef: { name: "main" },
+                  primaryLanguage: { name: "TypeScript" },
+                  repositoryTopics: { nodes: [] },
+                  stargazerCount: 42,
+                  forkCount: 2,
+                  issues: { totalCount: 7 },
+                  pullRequests: { totalCount: 3 },
+                  isArchived: false,
+                  isFork: false,
+                  isPrivate: false,
+                  pushedAt: "2026-05-15T00:00:00Z",
+                  updatedAt: "2026-05-15T00:00:00Z",
+                  releases: {
+                    nodes: [
+                      {
+                        tagName: "v1.0.0",
+                        name: null,
+                        url: "https://github.com/owner/repo/releases/tag/v1.0.0",
+                        isDraft: false,
+                        publishedAt: "2026-05-01T00:00:00Z",
+                      },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        },
+      });
+    }
+    if (url.pathname === "/repos/owner/repo/commits/main") {
+      return Response.json({
+        sha: "abcdef123456",
+        commit: { committer: { date: "2026-05-15T00:00:00Z" } },
+      });
+    }
+    if (url.pathname === "/repos/owner/repo/compare/v1.0.0...main") {
+      return Response.json({
+        total_commits: 3,
+        html_url: "https://github.com/owner/repo/compare/v1.0.0...main",
+      });
+    }
+    if (url.pathname === "/repos/owner/repo/commits/abcdef123456/check-runs") {
+      return Response.json({ check_runs: [] });
+    }
+    throw new Error(`unexpected fetch ${url.pathname}`);
+  };
+  const key = dashboardCacheKey({ owner: "owner", includeUnreleased: false, schemaVersion: 5 });
+  const dashboard = testDashboard("owner", [testProject({ owner: "owner", name: "repo" })]);
+  dashboard.generatedAt = new Date().toISOString();
+  if (dashboard.cache) {
+    dashboard.cache.generatedAt = dashboard.generatedAt;
+  }
+  const env = {
+    DASHBOARD_CACHE: kvStore({ [key]: JSON.stringify(dashboard) }),
+    GITHUB_TOKEN: "shared-token",
+  };
+  try {
+    const response = await worker.fetch(
+      new Request("https://release.bar/api/owner?unreleased=false", { method: "POST" }),
+      env,
+      { waitUntil: (promise) => waits.push(promise) },
+    );
+    assert.equal(response.status, 202);
+    const body = (await response.json()) as DashboardPayload;
+    assert.equal(body.projects.length, 1);
+    assert.equal(body.projects[0]?.version, "v1.0.0");
+    assert.match(body.cache?.message ?? "", /release data updating/);
+
+    await Promise.all(waits);
+    const cached = await worker.fetch(
+      new Request("https://release.bar/api/owner?unreleased=false"),
+      env,
+      { waitUntil: () => undefined },
+    );
+    const hydrated = (await cached.json()) as DashboardPayload;
+    assert.equal(hydrated.projects[0]?.openIssues, 7);
+    assert.equal(hydrated.projects[0]?.openPullRequests, 3);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("worker rejects POST to reserved read-only owner-like APIs", async () => {
+  for (const path of ["/api/me", "/api/_hot", "/api/_discover"]) {
+    const response = await worker.fetch(
+      new Request(`https://release.bar${path}`, { method: "POST" }),
+      {},
+      { waitUntil: () => undefined },
+    );
+    assert.equal(response.status, 405, path);
+  }
+});
+
 test("worker marks GitHub discovery hydration complete when release scan is rate limited", async () => {
   const originalFetch = globalThis.fetch;
   globalThis.fetch = async (input) => {

--- a/scripts/lib/dashboard.ts
+++ b/scripts/lib/dashboard.ts
@@ -1108,9 +1108,7 @@ export async function buildDashboard(options: DashboardBuildOptions): Promise<Da
       let ownerVisible = ownerExisting;
       let hydratedThisOwner = 0;
       let page = 1;
-      const scanLimit = includeReleaseData
-        ? (options.repoScanLimit ?? Number.POSITIVE_INFINITY)
-        : Number.POSITIVE_INFINITY;
+      const scanLimit = options.repoScanLimit ?? Number.POSITIVE_INFINITY;
       if (includeReleaseData && options.includeUnreleased) {
         const hydrateQueue: GitHubRepo[] = [];
         let metadataChanged = false;

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -148,6 +148,7 @@
   let adminLoading = false;
   let adminError = "";
   let adminActionMessage = "";
+  let manualRefreshLoading = false;
 
   const numberFormat = new Intl.NumberFormat("en", { notation: "compact" });
   const dateFormat = new Intl.DateTimeFormat("en", {
@@ -225,6 +226,7 @@
     (!data && !errorMessage) ||
     (data?.cache?.state === "rebuilding" && data.projects.length === 0);
   $: dashboardUpdating = data?.cache?.state === "partial";
+  $: manualRefreshAvailable = !adminRoute && !repoRoute && !initialRoute.isDefault;
   $: ownerToggles = data
     ? [...new Set(data.projects.map((project) => project.owner.toLowerCase()))].sort()
     : [];
@@ -1655,6 +1657,56 @@
     }
   }
 
+  async function manualRefreshDashboard(): Promise<void> {
+    if (!manualRefreshAvailable || manualRefreshLoading) return;
+    manualRefreshLoading = true;
+    generatedLabel = "refreshing";
+    generatedDetail = "refreshing issue and PR counts first";
+    errorMessage = "";
+    closeDashboardStream();
+    if (dashboardRefreshTimer !== null) {
+      globalThis.clearTimeout(dashboardRefreshTimer);
+      dashboardRefreshTimer = null;
+    }
+    const read = async (apiPath: string) => {
+      const response = await fetch(apiPath, { method: "POST", cache: "no-store" });
+      const body = await readDashboardResponse(response);
+      return { response, body };
+    };
+    try {
+      let { response, body } = await read(initialRoute.apiPath);
+      if (
+        initialRoute.fallbackApiPath &&
+        (!response.ok || !body || !("projects" in body))
+      ) {
+        ({ response, body } = await read(initialRoute.fallbackApiPath));
+      }
+      if (response.ok && body && "projects" in body) {
+        data = body;
+        updateStatus();
+        if (shouldAutoRefresh(data)) {
+          if (!startDashboardStream(0)) {
+            scheduleDashboardRefresh(0);
+          }
+        }
+        return;
+      }
+      const message =
+        body && "cache" in body && body.cache?.message
+          ? body.cache.message
+          : body && "error" in body
+            ? body.error
+            : `dashboard refresh failed: ${response.status}`;
+      throw new Error(message || `dashboard refresh failed: ${response.status}`);
+    } catch (error) {
+      errorMessage = error instanceof Error ? error.message : String(error);
+      generatedLabel = "refresh failed";
+      generatedDetail = errorMessage;
+    } finally {
+      manualRefreshLoading = false;
+    }
+  }
+
   async function loadRepoDetail(attempt = 0): Promise<void> {
     if (!repoRoute) return;
     const bypassCache = attempt > 0;
@@ -2220,6 +2272,23 @@
       {/if}
     </div>
     <div class="top-actions">
+      {#if manualRefreshAvailable}
+        <button
+          type="button"
+          class="refresh-toggle"
+          disabled={manualRefreshLoading}
+          onclick={manualRefreshDashboard}
+          aria-label="Refresh dashboard"
+          title="Refresh dashboard"
+        >
+          <svg viewBox="0 0 24 24" width="16" height="16" aria-hidden="true" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M21 12a9 9 0 0 1-15.2 6.5" />
+            <path d="M3 12A9 9 0 0 1 18.2 5.5" />
+            <path d="M18 2v4h-4" />
+            <path d="M6 22v-4h4" />
+          </svg>
+        </button>
+      {/if}
       <button
         type="button"
         class="status"

--- a/src/styles.css
+++ b/src/styles.css
@@ -322,7 +322,8 @@ h1 {
   white-space: nowrap;
 }
 
-.theme-toggle {
+.theme-toggle,
+.refresh-toggle {
   display: inline-flex;
   width: 32px;
   height: 32px;
@@ -341,15 +342,23 @@ h1 {
 }
 
 .theme-toggle:hover,
-.theme-toggle:focus-visible {
+.theme-toggle:focus-visible,
+.refresh-toggle:hover,
+.refresh-toggle:focus-visible {
   border-color: var(--green);
   color: var(--green);
   background: color-mix(in srgb, var(--green) 10%, transparent);
   outline: 0;
 }
 
-.theme-toggle svg {
+.theme-toggle svg,
+.refresh-toggle svg {
   display: block;
+}
+
+.refresh-toggle[disabled] {
+  cursor: wait;
+  opacity: 0.58;
 }
 
 .status {

--- a/src/styles.css
+++ b/src/styles.css
@@ -514,6 +514,21 @@ h1 {
   line-height: 1;
 }
 
+.trust-snapshot-score {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  align-items: center;
+  gap: 6px 10px;
+}
+
+.trust-snapshot-score .panel-kicker {
+  grid-column: 1 / -1;
+}
+
+.trust-snapshot-score .audience-tier {
+  justify-self: start;
+}
+
 .trust-snapshot button {
   min-height: 32px;
   white-space: nowrap;
@@ -886,6 +901,12 @@ input {
 
 input::placeholder {
   color: var(--muted);
+}
+
+.prompt input {
+  width: auto;
+  min-width: 0;
+  flex: 1 1 auto;
 }
 
 .metrics {
@@ -2815,32 +2836,124 @@ body.dev-mode .table-head .since-heading .label-compact {
 
 @media (max-width: 860px) {
   .shell {
-    width: min(100vw - 20px, 720px);
-    padding: 24px 0;
+    width: min(100vw - 16px, 720px);
+    padding: 18px 0 28px;
   }
 
   .topline {
-    display: block;
+    display: grid;
+    gap: 14px;
+    margin-bottom: 18px;
+  }
+
+  h1 {
+    font-size: clamp(36px, 12vw, 56px);
+  }
+
+  .subtitle {
+    margin-top: 10px;
+    font-size: 13px;
+  }
+
+  .hero-owner-title,
+  .hero-owner-link,
+  .repo-hero-title {
+    gap: 10px;
+  }
+
+  .hero-owner-avatar,
+  .repo-title-avatar {
+    width: clamp(48px, 15vw, 62px);
+    height: clamp(48px, 15vw, 62px);
+  }
+
+  .repo-actions {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 7px;
+  }
+
+  .repo-actions a {
+    min-width: 0;
+    min-height: 36px;
   }
 
   .top-actions {
     align-items: center;
-    justify-content: space-between;
+    justify-content: flex-start;
     flex-wrap: wrap;
-    margin-top: 18px;
+    gap: 8px;
+    margin-top: 0;
   }
 
   .status {
+    flex: 1 1 100%;
     margin-top: 0;
+    font-size: 12px;
+  }
+
+  .account-button {
+    width: auto;
+    min-width: min(164px, calc(100vw - 112px));
+  }
+
+  .account-label {
+    max-width: min(18ch, calc(100vw - 178px));
+  }
+
+  .discover-nav {
+    flex-wrap: nowrap;
+    gap: 10px;
+    margin: -2px -8px 16px;
+    padding: 0 8px 4px;
+    overflow-x: auto;
+    scrollbar-width: none;
+  }
+
+  .discover-nav::-webkit-scrollbar {
+    display: none;
+  }
+
+  .discover-group {
+    flex: 0 0 auto;
+    flex-wrap: nowrap;
+  }
+
+  .discover-group a {
+    white-space: nowrap;
   }
 
   .settings-panel,
   .settings-panel[data-open] {
     grid-template-columns: 1fr;
+    padding: 14px 44px 14px 14px;
+  }
+
+  .source-form,
+  .profile-actions {
+    grid-template-columns: 1fr;
+  }
+
+  .source-form button,
+  .profile-actions button {
+    min-height: 36px;
   }
 
   .metrics {
     grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .metrics .metric-action {
+    padding: 14px 12px;
+  }
+
+  .metrics span {
+    font-size: 24px;
+  }
+
+  .metrics small {
+    min-height: 28px;
+    line-height: 1.25;
   }
 
   .admin-toolbar {
@@ -2913,15 +3026,6 @@ body.dev-mode .table-head .since-heading .label-compact {
     grid-template-columns: 1fr;
   }
 
-  .project {
-    grid-template-columns: 1fr;
-    margin: 10px;
-    border: 1px solid var(--line);
-    border-radius: var(--radius);
-    overflow: hidden;
-    background: color-mix(in srgb, var(--panel) 38%, transparent);
-  }
-
   .trust-factors div {
     grid-template-columns: minmax(0, 1fr) 58px 48px;
   }
@@ -2952,9 +3056,25 @@ body.dev-mode .table-head .since-heading .label-compact {
     border-top: 1px solid var(--line);
   }
 
+  .filters {
+    flex-wrap: nowrap;
+    gap: 7px;
+    margin: 14px -8px;
+    padding: 0 8px 4px;
+    overflow-x: auto;
+    scrollbar-width: none;
+  }
+
+  .filters::-webkit-scrollbar {
+    display: none;
+  }
+
+  .filters button,
   .dev-toggle {
-    width: 100%;
+    flex: 0 0 auto;
+    width: auto;
     margin-left: 0;
+    white-space: nowrap;
   }
 
   .site-footer {
@@ -2962,21 +3082,83 @@ body.dev-mode .table-head .since-heading .label-compact {
     margin-top: -4px;
   }
 
+  .prompt {
+    display: flex;
+    min-height: 56px;
+    gap: 8px;
+    padding: 0 12px;
+  }
+
+  .prompt input {
+    order: 2;
+  }
+
   .quick-jump {
-    width: 64px;
-    min-width: 64px;
-    height: 40px;
+    order: 1;
+    width: 48px;
+    min-width: 48px;
+    flex: 0 0 48px;
+    height: 36px;
     gap: 7px;
-    padding: 0 10px;
+    padding: 0;
+  }
+
+  .table-wrap {
+    border: 0;
+    background: transparent;
+    overflow: visible;
   }
 
   .table-head {
+    position: sticky;
+    top: 0;
+    z-index: 4;
+    display: flex;
+    gap: 7px;
+    margin: 0 -8px 10px;
+    padding: 8px;
+    overflow-x: auto;
+    border: 1px solid var(--line);
+    border-radius: var(--radius);
+    background: color-mix(in srgb, var(--bg) 94%, transparent);
+    box-shadow: 0 12px 28px rgba(0, 0, 0, 0.22);
+    scrollbar-width: none;
+  }
+
+  .table-head::-webkit-scrollbar {
     display: none;
   }
 
-  .project {
-    grid-template-columns: 1fr;
-    margin: 10px;
+  .table-head button {
+    flex: 0 0 auto;
+    min-height: 34px;
+    border: 1px solid var(--line);
+    border-radius: 6px;
+    padding: 0 10px;
+    background: var(--panel);
+    white-space: nowrap;
+  }
+
+  .table-head button[aria-current="true"] {
+    border-color: var(--green);
+    background: rgba(156, 255, 87, 0.075);
+  }
+
+  .projects {
+    display: grid;
+    gap: 10px;
+  }
+
+  .project,
+  body.dev-mode .project {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    grid-template-areas:
+      "repo repo"
+      "release activity"
+      "since stars"
+      "issues prs"
+      "ci ci";
+    margin: 0;
     border: 1px solid var(--line);
     border-radius: var(--radius);
     overflow: hidden;
@@ -2984,13 +3166,46 @@ body.dev-mode .table-head .since-heading .label-compact {
   }
 
   .project > div {
-    border-right: 0;
     border-top: 1px solid var(--line);
-    padding: 12px 14px;
+    border-right: 0;
+    padding: 11px 12px;
   }
 
-  .project > div:first-child {
+  .repo-cell {
+    grid-area: repo;
     border-top: 0;
+  }
+
+  .stars-cell {
+    grid-area: stars;
+  }
+
+  .release-cell {
+    grid-area: release;
+    border-right: 1px solid var(--line);
+  }
+
+  .since-cell {
+    grid-area: since;
+    border-right: 1px solid var(--line);
+  }
+
+  .activity-cell {
+    grid-area: activity;
+  }
+
+  .issues-cell {
+    grid-area: issues;
+    border-right: 1px solid var(--line);
+  }
+
+  .prs-cell {
+    grid-area: prs;
+  }
+
+  .ci-cell {
+    grid-area: ci;
+    border-right: 0;
   }
 
   .release-cell::before,
@@ -3039,10 +3254,7 @@ body.dev-mode .table-head .since-heading .label-compact {
   .since-cell,
   .issues-cell,
   .prs-cell {
-    display: grid;
-    grid-template-columns: minmax(0, 1fr) auto;
-    align-items: baseline;
-    gap: 12px;
+    display: block;
   }
 
   .stars-cell::before,
@@ -3056,13 +3268,70 @@ body.dev-mode .table-head .since-heading .label-compact {
   .activity-cell,
   .ci-cell {
     display: grid;
-    grid-template-columns: minmax(0, 1fr) auto;
-    gap: 6px 12px;
+    grid-template-columns: minmax(0, 1fr);
+    gap: 5px;
   }
 
   .release-cell::before,
   .activity-cell::before,
   .ci-cell::before {
     grid-column: 1 / -1;
+  }
+
+  .repo-title {
+    align-items: flex-start;
+  }
+
+  .row-owner-avatar-link {
+    width: 24px;
+    height: 24px;
+    flex-basis: 24px;
+  }
+
+  .row-owner-avatar {
+    width: 20px;
+    height: 20px;
+  }
+
+  .description {
+    min-height: 0;
+    margin: 7px 0 9px;
+    -webkit-line-clamp: 2;
+    font-size: 12px;
+  }
+
+  .tags {
+    gap: 5px;
+    overflow: hidden;
+    max-height: 49px;
+  }
+
+  .tag {
+    min-height: 20px;
+    padding: 0 7px;
+    font-size: 10px;
+  }
+
+  .release-version {
+    margin-top: 2px;
+  }
+
+  .release-cell span,
+  .activity-cell span,
+  .ci-cell span {
+    margin-top: 0;
+  }
+
+  .since-cell a,
+  .since-cell {
+    font-size: 26px;
+    line-height: 1;
+  }
+
+  .issues-cell a,
+  .prs-cell a,
+  .stars-cell strong {
+    font-size: 22px;
+    line-height: 1;
   }
 }

--- a/worker/index.ts
+++ b/worker/index.ts
@@ -200,6 +200,8 @@ const refreshJobPrefix = `refresh:job:v1:`;
 const refreshJobIndexKey = `refresh:jobs:index:v1`;
 const refreshAuditPrefix = `refresh:audit:v2:`;
 const refreshStateKey = `refresh:state:v1`;
+const manualRefreshCooldownPrefix = `refresh:manual:v1:`;
+const manualRefreshCooldownSeconds = 10 * 60;
 const refreshTargetListLimit = 5000;
 const refreshJobListLimit = 80;
 const refreshAuditListLimit = 80;
@@ -264,6 +266,12 @@ function isOwnerEventsApiPath(pathname: string): boolean {
 function isOwnerApiPath(pathname: string): boolean {
   const parts = pathname.split("/").filter(Boolean);
   return parts.length === 2 && parts[0] === "api";
+}
+
+function isOwnerRefreshApiPath(pathname: string): boolean {
+  const parts = pathname.split("/").filter(Boolean);
+  const owner = parts[1] ?? "";
+  return isOwnerApiPath(pathname) && owner !== "me" && !owner.startsWith("_");
 }
 
 function isTrustProfileApiPath(pathname: string): boolean {
@@ -2491,6 +2499,20 @@ function cacheAgeMs(payload: DashboardPayload | null): number {
 
 function canDisplayCached(payload: DashboardPayload | null): payload is DashboardPayload {
   return cacheAgeMs(payload) <= maxDisplayStaleMs;
+}
+
+async function manualRefreshCooldownKey(key: string): Promise<string> {
+  return `${manualRefreshCooldownPrefix}${(await sha256Base64Url(key)).slice(0, 32)}`;
+}
+
+async function manualRefreshCooldownActive(env: Env, key: string): Promise<boolean> {
+  return Boolean(await env.DASHBOARD_CACHE?.get(await manualRefreshCooldownKey(key)));
+}
+
+async function markManualRefreshCooldown(env: Env, key: string): Promise<void> {
+  await env.DASHBOARD_CACHE?.put(await manualRefreshCooldownKey(key), new Date().toISOString(), {
+    expirationTtl: manualRefreshCooldownSeconds,
+  });
 }
 
 function profileKey(owner: string): string {
@@ -7844,6 +7866,89 @@ async function continueProgressiveBuild(dashboard: DashboardRequest, env: Env): 
   });
 }
 
+async function refreshDashboardMetadataFirst(
+  dashboard: DashboardRequest,
+  env: Env,
+): Promise<DashboardPayload | null> {
+  const lock = await acquireBuildLock(env, dashboard.key);
+  if (!lock) {
+    await auditSyncEvent(env, {
+      event: "dashboard_manual_refresh_skip",
+      targetKey: dashboard.key,
+      status: "locked",
+      reason: "build-lock",
+    });
+    return null;
+  }
+
+  const refresh = globalThis.setInterval(() => {
+    void lock.refresh();
+  }, buildLockRefreshMs);
+  const startedAt = Date.now();
+  await deleteProgress(env, dashboard.key);
+  await auditSyncEvent(env, {
+    event: "dashboard_manual_refresh_start",
+    targetKey: dashboard.key,
+    status: "running",
+    detail: "phase=metadata",
+  });
+  try {
+    const payload = await buildDashboard({
+      title: "ReleaseBar",
+      subtitle: dashboard.subtitle,
+      canonicalDomain: env.RELEASEDECK_CANONICAL_DOMAIN ?? "release.bar",
+      owners: dashboard.owners,
+      includeRepos: dashboard.includeRepos,
+      excludeRepos: dashboard.profile?.hiddenRepos,
+      ...optionsFromUrl(dashboard.url),
+      repoLimit,
+      repoScanLimit: 0,
+      repoScanTarget: repoLimit,
+      token: dashboard.token ?? env.GITHUB_TOKEN,
+      includeReleaseData: false,
+      quotaSource:
+        dashboard.quotaSource ?? (dashboard.token || env.GITHUB_TOKEN ? "shared" : "anonymous"),
+      quotaAccount: dashboard.quotaAccount ?? null,
+      fetch: auditGitHubFetch(
+        "dashboard",
+        dashboard.quotaSource ?? (dashboard.token || env.GITHUB_TOKEN ? "shared" : "anonymous"),
+        dashboard.quotaAccount ?? null,
+      ),
+      projectCache: env.DASHBOARD_CACHE,
+    });
+    const partial = withCacheState(
+      payload,
+      "partial",
+      "issue and PR counts refreshed; release data updating",
+    );
+    if (partial.cache?.progress) {
+      partial.cache.progress.done = false;
+    }
+    const profiled = withProfile(partial, dashboard.profile);
+    await writeCached(env, dashboard.key, profiled);
+    await writeProgress(env, dashboard.key, {
+      scannedRepos: [],
+      projects: profiled.projects,
+      updatedAt: profiled.generatedAt,
+    });
+    await auditSyncEvent(env, {
+      event: "dashboard_manual_refresh_metadata_done",
+      targetKey: dashboard.key,
+      status: "partial",
+      durationMs: Date.now() - startedAt,
+      projects: profiled.projects.length,
+      scanned: profiled.cache?.progress?.scanned,
+      limit: profiled.cache?.progress?.limit,
+      done: profiled.cache?.progress?.done,
+      detail: dashboardSyncDetail(profiled),
+    });
+    return profiled;
+  } finally {
+    globalThis.clearInterval(refresh);
+    await lock.release();
+  }
+}
+
 function errorPayload(dashboard: DashboardRequest, env: Env, message: string): DashboardPayload {
   return statusPayload(dashboard, env, "error", message, new Date().toISOString());
 }
@@ -8107,6 +8212,133 @@ async function ownerResponse(
     done: cached?.cache?.progress?.done,
     detail: `ageMs=${ageMs} owners=${ownerSlugs.length} repos=${includeRepos.length} includeReleaseData=${includeReleaseData}`,
   });
+
+  if (request.method === "POST") {
+    if (await manualRefreshCooldownActive(env, key)) {
+      await auditSyncEvent(env, {
+        event: "dashboard_manual_refresh_skip",
+        targetKey: key,
+        status: "cooldown",
+        reason: "cooldown",
+        detail: `cooldownSeconds=${manualRefreshCooldownSeconds}`,
+      });
+      if (displayCached) {
+        const state = cached.cache?.progress?.done === false ? "partial" : "stale";
+        return jsonResponse(
+          withCacheState(
+            cached,
+            state,
+            "manual refresh recently started; showing cached dashboard",
+          ),
+          202,
+          {
+            "cache-control": "no-store",
+            ...corsHeaders,
+          },
+        );
+      }
+      return jsonResponse({ error: "manual refresh recently started" }, 429, {
+        "cache-control": "no-store",
+        ...corsHeaders,
+      });
+    }
+    let owners: Owner[] | null = cached?.owners ?? null;
+    if (!owners) {
+      try {
+        owners = await resolveOwners(
+          ownerSlugs,
+          env,
+          token?.token,
+          token?.quotaSource,
+          token?.quotaAccount ?? null,
+        );
+      } catch (error) {
+        return jsonResponse({ error: dashboardErrorMessage(error) }, errorStatus(error), {
+          ...retryAfterHeaders(error),
+          ...corsHeaders,
+        });
+      }
+    }
+    if (!owners) {
+      return jsonResponse({ error: "owner not found" }, 404, {
+        "cache-control": "no-store",
+        ...corsHeaders,
+      });
+    }
+    const dashboard = dashboardRequest(
+      owners,
+      includeRepos,
+      profile,
+      key,
+      url,
+      includeReleaseData,
+      token,
+    );
+    if (!options.includeUnreleased) {
+      await markManualRefreshCooldown(env, key);
+      const build = rebuildWithBuildLock(dashboard, env);
+      context.waitUntil(
+        build
+          .then((built) =>
+            built?.cache?.progress?.done === false
+              ? continueProgressiveBuild(dashboard, env)
+              : undefined,
+          )
+          .catch((error) => cacheBuildError(dashboard, env, error)),
+      );
+      if (displayCached) {
+        return jsonResponse(
+          withCacheState(cached, "stale", "manual refresh started; release data updating"),
+          202,
+          {
+            "cache-control": "no-store",
+            ...corsHeaders,
+          },
+        );
+      }
+      return jsonResponse(rebuildingPayload(dashboard, env), 202, {
+        "cache-control": "no-store",
+        ...corsHeaders,
+      });
+    }
+
+    let payload: DashboardPayload | null;
+    try {
+      payload = await refreshDashboardMetadataFirst(dashboard, env);
+    } catch (error) {
+      const failed = errorPayload(dashboard, env, dashboardErrorMessage(error));
+      if (!displayCached) {
+        await writeCached(env, key, failed, 5 * 60);
+      }
+      return jsonResponse(failed, errorStatus(error), {
+        ...retryAfterHeaders(error),
+        ...corsHeaders,
+      });
+    }
+    if (payload) {
+      await markManualRefreshCooldown(env, key);
+      context.waitUntil(
+        continueProgressiveBuild(dashboard, env).catch((error) =>
+          cacheBuildError(dashboard, env, error),
+        ),
+      );
+      return jsonResponse(payload, 202, { "cache-control": "no-store", ...corsHeaders });
+    }
+    if (displayCached) {
+      return jsonResponse(
+        withCacheState(cached, "partial", "manual refresh already running"),
+        202,
+        {
+          "cache-control": "no-store",
+          ...corsHeaders,
+        },
+      );
+    }
+    return jsonResponse(rebuildingPayload(dashboard, env), 202, {
+      "cache-control": "no-store",
+      ...corsHeaders,
+    });
+  }
 
   if (displayCached && cached.cache?.state === "error") {
     const dashboard = cachedDashboardRequest(
@@ -8408,6 +8640,7 @@ export default {
     const audienceBackfillWrite =
       isRepoAudienceBackfillApiPath(url.pathname) && request.method === "POST";
     const adminWrite = url.pathname === "/api/admin/scheduler/run" && request.method === "POST";
+    const ownerRefreshWrite = isOwnerRefreshApiPath(url.pathname) && request.method === "POST";
     const clientTimingWrite = url.pathname === "/api/_client-timing" && request.method === "POST";
     if (
       request.method !== "GET" &&
@@ -8415,6 +8648,7 @@ export default {
       !profileWrite &&
       !audienceBackfillWrite &&
       !adminWrite &&
+      !ownerRefreshWrite &&
       !clientTimingWrite
     ) {
       return jsonResponse({ error: "method not allowed" }, 405, { allow: "GET" });


### PR DESCRIPTION
Summary:
- Add a manual dashboard refresh button on owner/custom dashboards.
- POST refresh updates cheap repository metadata first, then continues release hydration in the background.
- Add cooldown, structured error handling, released-only fallback, and reserved API POST guards.

Tests:
- npm run check:static
- autoreview --mode local
