### PR TITLE
feat: support tokenized dashboard search

### DIFF
--- a/scripts/lib/dashboard.test.ts
+++ b/scripts/lib/dashboard.test.ts
@@ -28,6 +28,7 @@ import {
 } from "../../src/routing.js";
 import {
   attentionReasons,
+  matchesProjectSearch,
   needsAttention,
   parseViewState,
   showCodeChurn,
@@ -527,6 +528,26 @@ test("dashboard project sorting handles dev issue and pull request counts numeri
     ).map((project) => project.name),
     ["large", "small"],
   );
+});
+
+test("dashboard project search matches independent metadata terms", () => {
+  const project = testProject({
+    owner: "owner",
+    name: "releasebar",
+    description: "Manual refresh dashboard",
+    language: "TypeScript",
+    topics: ["cloudflare", "worker"],
+    version: "v1.2.3",
+    releaseName: "Ship dashboard search",
+    ciState: "failure",
+    ciWorkflow: "CI",
+  });
+
+  assert.equal(matchesProjectSearch(project, ""), true);
+  assert.equal(matchesProjectSearch(project, "typescript v1.2.3"), true);
+  assert.equal(matchesProjectSearch(project, "owner worker ci"), true);
+  assert.equal(matchesProjectSearch(project, "ship failure"), true);
+  assert.equal(matchesProjectSearch(project, "typescript swift"), false);
 });
 
 test("dashboard stream signature changes when dev sort counts change", () => {

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -15,6 +15,7 @@
     filterOptions,
     isDevSortKey,
     matchesFilter,
+    matchesProjectSearch,
     attentionReasons,
     needsAttention,
     parseViewState,
@@ -583,22 +584,7 @@
     if (hiddenOwnerSet.has(project.owner.toLowerCase())) return false;
     if (hiddenRepoSet.has(project.fullName.toLowerCase())) return false;
     if (languageQuery && project.language?.toLowerCase() !== languageQuery.toLowerCase()) return false;
-    const normalizedQuery = searchQuery.trim().toLowerCase();
-    if (!normalizedQuery) return true;
-    const haystack = [
-      project.fullName,
-      project.description,
-      project.language,
-      ...(project.topics ?? []),
-      project.version,
-      project.freshness,
-      project.ciState,
-      project.ciWorkflow,
-    ]
-      .filter(Boolean)
-      .join(" ")
-      .toLowerCase();
-    return haystack.includes(normalizedQuery);
+    return matchesProjectSearch(project, searchQuery);
   }
 
   function persistVisibility(nextOwners = hiddenOwners, nextRepos = hiddenRepos): void {

--- a/src/dashboard-view.ts
+++ b/src/dashboard-view.ts
@@ -139,6 +139,26 @@ export function matchesFilter(project: Project, value: DashboardFilter): boolean
   return project.freshness === value;
 }
 
+export function matchesProjectSearch(project: Project, query: string): boolean {
+  const terms = query.trim().toLowerCase().split(/\s+/).filter(Boolean);
+  if (terms.length === 0) return true;
+  const haystack = [
+    project.fullName,
+    project.description,
+    project.language,
+    ...(project.topics ?? []),
+    project.version,
+    project.releaseName,
+    project.freshness,
+    project.ciState,
+    project.ciWorkflow,
+  ]
+    .filter(Boolean)
+    .join(" ")
+    .toLowerCase();
+  return terms.every((term) => haystack.includes(term));
+}
+
 export function sortValue(project: Project, key: SortKey): string | number {
   switch (key) {
     case "repo":


### PR DESCRIPTION
## Summary
- add shared tokenized project search so dashboard queries like `typescript ci` can match terms across different metadata fields
- include release names in the searchable project metadata
- replace the inline Svelte haystack search with the shared helper and add regression coverage

## Behavior proof
Captured on the PR branch `feat/tokenized-dashboard-search` at `6801758` on May 24, 2026. The branch-local compiled helper was exercised with a sample dashboard project that has `language: "TypeScript"`, `ciWorkflow: "ci"`, and `releaseName: "Fastlane CI polish"`.

```console
> npm run build:script

> releasebar@0.1.0 build:script
> tsc -p tsconfig.build.json
```

```console
> node --input-type=module

typescript ci => true (matches tokens split across language + CI workflow/release name)
fastlane polish => true (matches tokens from releaseName)
typescript missing => false (requires every token to be present)
```

## Verification
- npm run test
- npm run lint
- npm run typecheck
- npm run build:app
- npx oxfmt --check src/dashboard-view.ts src/App.svelte scripts/lib/dashboard.test.ts

Note: `npm run format:check` reports formatting issues across the Windows checkout, including many untouched files, apparently due to local line-ending normalization. The touched files pass a targeted `oxfmt --check`.