### PR TITLE
fix: clear ReleaseBar Hot language state

### DIFF
--- a/scripts/lib/dashboard.test.ts
+++ b/scripts/lib/dashboard.test.ts
@@ -386,6 +386,7 @@ test("owner route parsing keeps root hot board and owners API-backed", () => {
     dashboardRoute("/", "?period=releasebar&hotLang=TypeScript").apiPath,
     `${workerApiOrigin}/api/_hot`,
   );
+  assert.equal(dashboardRoute("/", "?period=releasebar&hotLang=TypeScript").discoverLanguage, "");
   assert.equal(
     dashboardRoute("/", "?period=day&lang=TypeScript").apiPath,
     `${workerApiOrigin}/api/_discover?period=day`,

--- a/src/routing.ts
+++ b/src/routing.ts
@@ -168,7 +168,8 @@ export function dashboardRoute(
   if (!owner) {
     const custom = extraOwners.length > 0 || repos.length > 0;
     const discoverPeriod = discoverPeriodFromSearch(search);
-    const discoverLanguage = discoverLanguageFromSearch(search);
+    const discoverLanguage =
+      discoverPeriod === "releasebar" ? "" : discoverLanguageFromSearch(search);
     const discoverQuery = new URLSearchParams();
     if (discoverPeriod !== "week") discoverQuery.set("period", discoverPeriod);
     if (discoverLanguage) discoverQuery.set("lang", discoverLanguage);


### PR DESCRIPTION
## Summary
- clear `hotLang` route state when the root dashboard is using `period=releasebar`
- keep the API route on `/api/_hot` while preventing the UI from marking an ignored language filter active
- add a routing regression assertion

## Verification
- npm run test
- npm run lint
- npm run typecheck
- npm run build:app
- npx oxfmt --check src/routing.ts scripts/lib/dashboard.test.ts