### PR TITLE
fix: make trust snapshot background theme-aware

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -487,7 +487,7 @@ h1 {
   border: 1px solid var(--line);
   border-radius: var(--radius);
   padding: 14px 16px;
-  background: rgba(16, 19, 15, 0.68);
+  background: color-mix(in srgb, var(--panel) 82%, transparent);
 }
 
 .trust-snapshot > div {


### PR DESCRIPTION
## Summary                                                                   
  - make the trust snapshot background theme-aware instead of hard-coding a    
dark translucent background                                                    
  - preserve the existing dark-mode feel while improving light-mode readability
                                                                               
  ## Testing                                                                   
  - npm run typecheck                                                          
  - npm run lint                                                               
  - npm run format:check                                                       
  - npm run check:static                                                       
                                                                               
  Closes #32         