### PR TITLE
fix: tolerate malformed owner activity events

### DIFF
--- a/scripts/lib/dashboard.test.ts
+++ b/scripts/lib/dashboard.test.ts
@@ -3417,6 +3417,17 @@ test("worker summarizes public owner activity in the background", async () => {
           },
         },
         {
+          id: "repo-missing",
+          type: "PushEvent",
+          public: true,
+          created_at: generatedAt,
+          repo: {},
+          payload: {
+            size: 1,
+            commits: [{ message: "This malformed event should be ignored" }],
+          },
+        },
+        {
           id: "3",
           type: "PushEvent",
           public: false,

--- a/worker/index.ts
+++ b/worker/index.ts
@@ -5159,11 +5159,11 @@ function activityRepoUrl(repo: string): string {
 
 function normalizeActivityEvent(event: GitHubPublicEvent): OwnerActivityEvent | null {
   if (event.public === false) return null;
-  const repo = event.repo.name;
+  const repo = event.repo?.name?.trim() ?? "";
   const payload = event.payload;
   const createdAt = event.created_at;
-  const repoUrl = activityRepoUrl(repo);
   if (!repo || !createdAt) return null;
+  const repoUrl = activityRepoUrl(repo);
 
   if (event.type === "PushEvent") {
     const payloadData = payloadRecord(payload);

--- a/worker/schemas.ts
+++ b/worker/schemas.ts
@@ -234,9 +234,11 @@ export const gitHubPublicEventSchema = v.looseObject({
   type: v.string(),
   public: v.optional(v.boolean()),
   created_at: v.string(),
-  repo: v.looseObject({
-    name: v.string(),
-  }),
+  repo: v.optional(
+    v.looseObject({
+      name: v.optional(v.string()),
+    }),
+  ),
   payload: v.optional(v.unknown()),
 });
 


### PR DESCRIPTION
## Summary
- tolerate malformed GitHub public activity events with missing repository names
- harden owner activity normalization so one bad event does not fail the full endpoint
- add regression coverage for a public event with `repo: {}`

## Testing
- npm run typecheck
- npm run test
- npm run lint
- npm run format:check

Closes #33
