### PR TITLE
fix(audience): stop classifying human logins ending in "bot" as automation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Stopped classifying human audience logins that merely end in `bot` as automation when GitHub account metadata does not identify them as bots. Thanks @devYRPauli.
 - Clarified trust score tooltips for owner, organization, contributor, and stargazer signals. Thanks @vincent-peng.
 - Made dashboard search match separate terms across repository metadata and release names. Thanks @tanish19078.
 - Kept light-mode trust panels on theme-aware surfaces instead of dark translucent backgrounds. Thanks @shubh73.

--- a/docs/api.md
+++ b/docs/api.md
@@ -136,7 +136,7 @@ type TrustProfilePayload = {
 
 ### Score Semantics
 
-`score` is a 0-100 public-signal score. `tier` is derived from that score, except obvious automation accounts return `bot`.
+`score` is a 0-100 public-signal score. `tier` is derived from that score, except obvious automation accounts return `bot`. Bot classification prefers GitHub account metadata (`Bot` or app identities) when available, then falls back to explicit `[bot]` logins, exact `bot`, known automation prefixes such as `dependabot`, `renovate`, and `github-actions`, or separator-delimited `bot` markers such as `ci.bot` and `release-bot`. Ambiguous no-separator names such as `crawlerbot`, `robot`, or `gpt4bot` require account metadata instead of a broad `*bot` suffix guess.
 
 For `profileKind: "user_trust"`, the score describes a person/account as a public GitHub actor. For `profileKind: "org_signal"`, the score describes an organization's public footprint and credibility. These are intentionally not the same semantic label.
 

--- a/scripts/lib/audience.ts
+++ b/scripts/lib/audience.ts
@@ -136,11 +136,16 @@ const notableOrgKeywords = [
   "vercel",
 ];
 
+// Treat "bot" as a bot marker only when it is a standalone trailing token
+// (e.g. my-bot, ci.bot, gpt4bot, or exactly "bot"), not when it is the tail of
+// an ordinary human login such as cabot, talbot, or abbot. Real GitHub App
+// accounts always carry the explicit "[bot]" suffix, matched separately below.
+const BOT_SUFFIX = /(?:^|[^a-z])bot$/;
+
 export function isLikelyBot(login: string): boolean {
   const normalized = login.toLowerCase();
   return (
-    normalized.endsWith("bot") ||
-    normalized.endsWith("-bot") ||
+    BOT_SUFFIX.test(normalized) ||
     normalized.endsWith("[bot]") ||
     normalized.includes("bot-") ||
     normalized.startsWith("github-actions") ||

--- a/scripts/lib/audience.ts
+++ b/scripts/lib/audience.ts
@@ -47,6 +47,7 @@ export type AudienceScoreFactor = {
 
 export type AudienceScoreInput = {
   login: string;
+  accountType?: string | null;
   followers: number;
   following?: number;
   publicRepos: number;
@@ -136,22 +137,30 @@ const notableOrgKeywords = [
   "vercel",
 ];
 
-// Treat "bot" as a bot marker only when it is a standalone trailing token
-// (e.g. my-bot, ci.bot, gpt4bot, or exactly "bot"), not when it is the tail of
-// an ordinary human login such as cabot, talbot, or abbot. Real GitHub App
-// accounts always carry the explicit "[bot]" suffix, matched separately below.
-const BOT_SUFFIX = /(?:^|[^a-z])bot$/;
+const knownBotLoginPrefixes = ["github-actions", "dependabot", "renovate"];
+const botTokenPattern = /(?:^|[-_.])bot(?:$|[-_.])/;
 
-export function isLikelyBot(login: string): boolean {
-  const normalized = login.toLowerCase();
-  return (
-    BOT_SUFFIX.test(normalized) ||
-    normalized.endsWith("[bot]") ||
-    normalized.includes("bot-") ||
-    normalized.startsWith("github-actions") ||
-    normalized.startsWith("dependabot") ||
-    normalized.startsWith("renovate")
+// Account type comes from GitHub profile metadata when available. Login fallback
+// stays narrow; no broad "*bot" suffix guess for ambiguous human-looking names.
+function hasKnownBotLoginPrefix(normalized: string): boolean {
+  return knownBotLoginPrefixes.some(
+    (prefix) =>
+      normalized === prefix ||
+      normalized === `${prefix}bot` ||
+      normalized.startsWith(`${prefix}-`) ||
+      normalized.startsWith(`${prefix}.`) ||
+      normalized.startsWith(`${prefix}_`) ||
+      normalized.startsWith(`${prefix}[`) ||
+      normalized.startsWith(`${prefix}bot-`),
   );
+}
+
+export function isLikelyBot(login: string, accountType?: string | null): boolean {
+  const normalized = login.toLowerCase();
+  const normalizedType = accountType?.toLowerCase();
+  if (normalizedType === "bot" || normalizedType === "app") return true;
+  if (normalized.endsWith("[bot]")) return true;
+  return botTokenPattern.test(normalized) || hasKnownBotLoginPrefix(normalized);
 }
 
 function usefulText(value: string | null | undefined): string {
@@ -208,7 +217,7 @@ function factor(
 }
 
 export function calculateAudienceScore(input: AudienceScoreInput): AudienceScore {
-  if (isLikelyBot(input.login)) {
+  if (isLikelyBot(input.login, input.accountType)) {
     return {
       score: 0,
       tier: "bot",

--- a/scripts/lib/dashboard.test.ts
+++ b/scripts/lib/dashboard.test.ts
@@ -759,6 +759,45 @@ test("audience scoring uses only public profile and stargazer signals", () => {
   assert.equal(low.factors.find((factor) => factor.key === "risk")?.sentiment, "negative");
 });
 
+test("isLikelyBot flags automation without misclassifying human logins ending in bot", () => {
+  // Real automation accounts are still detected.
+  for (const login of [
+    "dependabot",
+    "renovate",
+    "github-actions[bot]",
+    "my-bot",
+    "foo[bot]",
+    "gpt4bot",
+    "bot",
+  ]) {
+    assert.equal(isLikelyBot(login), true, `${login} should be detected as a bot`);
+  }
+
+  // Ordinary human logins that merely end in the letters "bot" are not.
+  for (const login of ["cabot", "talbot", "abbot", "wilbot", "arbot"]) {
+    assert.equal(isLikelyBot(login), false, `${login} should not be treated as a bot`);
+  }
+
+  // A strong human profile whose login ends in "bot" is scored, not zeroed out.
+  const human = calculateAudienceScore({
+    login: "cabot",
+    followers: 5000,
+    following: 50,
+    publicRepos: 80,
+    publicGists: 2,
+    company: "GitHub",
+    bio: "Principal engineer",
+    location: "SF",
+    blog: null,
+    twitterUsername: null,
+    accountCreatedAt: "2015-01-01T00:00:00Z",
+    accountUpdatedAt: "2026-05-18T00:00:00Z",
+    starredAt: "2026-05-18T00:00:00Z",
+  });
+  assert.notEqual(human.tier, "bot");
+  assert.ok(human.score > 0);
+});
+
 test("need attention explains release debt, stale releases, CI, and open work", () => {
   const stale = testProject({
     owner: "owner",

--- a/scripts/lib/dashboard.test.ts
+++ b/scripts/lib/dashboard.test.ts
@@ -759,28 +759,55 @@ test("audience scoring uses only public profile and stargazer signals", () => {
   assert.equal(low.factors.find((factor) => factor.key === "risk")?.sentiment, "negative");
 });
 
-test("isLikelyBot flags automation without misclassifying human logins ending in bot", () => {
-  // Real automation accounts are still detected.
+test("isLikelyBot uses account type before narrow login fallbacks", () => {
+  // GitHub account metadata is authoritative when it is available.
+  for (const login of ["cabot", "crawlerbot", "robot", "gpt4bot"]) {
+    assert.equal(isLikelyBot(login, "Bot"), true, `${login} with Bot type should be a bot`);
+    assert.equal(isLikelyBot(login, "App"), true, `${login} with App type should be a bot`);
+    assert.equal(isLikelyBot(login, "User"), false, `${login} with User type should be human`);
+  }
+
+  // Narrow lexical fallback for callers that do not have account type metadata.
   for (const login of [
     "dependabot",
     "renovate",
+    "github-actions",
     "github-actions[bot]",
     "my-bot",
+    "ci.bot",
+    "bot-ci",
     "foo[bot]",
-    "gpt4bot",
     "bot",
   ]) {
     assert.equal(isLikelyBot(login), true, `${login} should be detected as a bot`);
   }
 
-  // Ordinary human logins that merely end in the letters "bot" are not.
-  for (const login of ["cabot", "talbot", "abbot", "wilbot", "arbot"]) {
-    assert.equal(isLikelyBot(login), false, `${login} should not be treated as a bot`);
+  for (const login of ["renovate-bot", "bot-ci", "foo[bot]", "github-actions"]) {
+    assert.equal(
+      isLikelyBot(login, "User"),
+      true,
+      `${login} should keep explicit bot fallback with User metadata`,
+    );
+  }
+
+  // No-separator *bot names are ambiguous without metadata, so do not guess.
+  for (const login of [
+    "cabot",
+    "talbot",
+    "abbot",
+    "wilbot",
+    "arbot",
+    "crawlerbot",
+    "robot",
+    "gpt4bot",
+  ]) {
+    assert.equal(isLikelyBot(login), false, `${login} should require metadata before bot tier`);
   }
 
   // A strong human profile whose login ends in "bot" is scored, not zeroed out.
   const human = calculateAudienceScore({
     login: "cabot",
+    accountType: "User",
     followers: 5000,
     following: 50,
     publicRepos: 80,
@@ -796,6 +823,26 @@ test("isLikelyBot flags automation without misclassifying human logins ending in
   });
   assert.notEqual(human.tier, "bot");
   assert.ok(human.score > 0);
+
+  const typedBot = calculateAudienceScore({
+    login: "octocat",
+    accountType: "Bot",
+    followers: 5000,
+    following: 50,
+    publicRepos: 80,
+    publicGists: 2,
+    company: "GitHub",
+    bio: "Automation",
+    location: "CI",
+    blog: null,
+    twitterUsername: null,
+    accountCreatedAt: "2015-01-01T00:00:00Z",
+    accountUpdatedAt: "2026-05-18T00:00:00Z",
+    starredAt: "2026-05-18T00:00:00Z",
+  });
+  assert.equal(typedBot.score, 0);
+  assert.equal(typedBot.tier, "bot");
+  assert.deepEqual(typedBot.reasons, ["automation account"]);
 });
 
 test("need attention explains release debt, stale releases, CI, and open work", () => {
@@ -2060,6 +2107,7 @@ test("worker builds cached repository audience from public stargazers", async ()
                 {
                   starredAt: new Date().toISOString(),
                   node: {
+                    __typename: "User",
                     login: "principal",
                     avatarUrl: "https://avatars.githubusercontent.com/u/10",
                     url: "https://github.com/principal",
@@ -2068,6 +2116,16 @@ test("worker builds cached repository audience from public stargazers", async ()
                 {
                   starredAt: new Date().toISOString(),
                   node: {
+                    __typename: "User",
+                    login: "cabot",
+                    avatarUrl: "https://avatars.githubusercontent.com/u/13",
+                    url: "https://github.com/cabot",
+                  },
+                },
+                {
+                  starredAt: new Date().toISOString(),
+                  node: {
+                    __typename: "User",
                     login: "quiet",
                     avatarUrl: "https://avatars.githubusercontent.com/u/11",
                     url: "https://github.com/quiet",
@@ -2076,6 +2134,7 @@ test("worker builds cached repository audience from public stargazers", async ()
                 {
                   starredAt: new Date().toISOString(),
                   node: {
+                    __typename: "Bot",
                     login: "renovate-bot",
                     avatarUrl: "https://avatars.githubusercontent.com/u/12",
                     url: "https://github.com/renovate-bot",
@@ -2156,6 +2215,32 @@ test("worker builds cached repository audience from public stargazers", async ()
         created_at: "2012-01-01T00:00:00Z",
         updated_at: "2026-05-16T12:00:00Z",
       });
+    }
+    if (path === "/users/cabot") {
+      return Response.json({
+        login: "cabot",
+        avatar_url: "https://avatars.githubusercontent.com/u/13",
+        html_url: "https://github.com/cabot",
+        type: "User",
+        name: "C. Abot",
+        company: "GitHub",
+        bio: "Principal engineer building developer tools",
+        location: "San Francisco",
+        blog: "https://cabot.dev",
+        twitter_username: "cabot",
+        followers: 5000,
+        following: 50,
+        public_repos: 80,
+        public_gists: 2,
+        created_at: "2015-01-01T00:00:00Z",
+        updated_at: "2026-05-16T12:00:00Z",
+      });
+    }
+    if (path === "/users/cabot/orgs") {
+      return Response.json([]);
+    }
+    if (path === "/users/cabot/repos") {
+      return Response.json([]);
     }
     if (path === "/users/principal/orgs") {
       return Response.json([
@@ -2267,13 +2352,17 @@ test("worker builds cached repository audience from public stargazers", async ()
     assert.equal(body.users[0]?.orgs[0]?.login, "github");
     assert.equal(body.users[0]?.topRepositories[0]?.fullName, "principal/release-tools");
     assert.match(body.users[0]?.reasons.join(" ") ?? "", /notable org: github/);
+    const cabot = body.users.find((user) => user.login === "cabot");
+    assert.notEqual(cabot?.tier, "bot");
+    assert.ok((cabot?.score ?? 0) > 0);
     assert.equal(body.totals.stargazers, 1234);
     assert.equal(body.totals.highSignal, 1);
+    assert.equal(body.totals.mediumSignal, 1);
     assert.equal(body.totals.bots, 1);
-    assert.equal(body.totals.highSignalPercent, 33);
-    assert.equal(body.totals.mediumSignalPercent, 0);
-    assert.equal(body.totals.lowSignalPercent, 33);
-    assert.equal(body.totals.botPercent, 33);
+    assert.equal(body.totals.highSignalPercent, 25);
+    assert.equal(body.totals.mediumSignalPercent, 25);
+    assert.equal(body.totals.lowSignalPercent, 25);
+    assert.equal(body.totals.botPercent, 25);
     assert.equal(body.cache.quota?.source, "shared");
 
     const cached = await worker.fetch(
@@ -2282,7 +2371,7 @@ test("worker builds cached repository audience from public stargazers", async ()
       { waitUntil: () => undefined },
     );
     assert.equal(cached.status, 200);
-    assert.equal(calls, 9);
+    assert.equal(calls, 12);
   } finally {
     globalThis.fetch = originalFetch;
   }
@@ -2829,6 +2918,59 @@ test("worker builds bounded trust profiles for people pages", async () => {
       "/users/principal/orgs",
       "/users/principal/repos",
     ]);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("worker preserves bot tier for typed trust profiles", async () => {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (input) => {
+    const url = new URL(String(input));
+    if (url.pathname === "/users/crawlerbot") {
+      return Response.json({
+        login: "crawlerbot",
+        avatar_url: "https://avatars.githubusercontent.com/u/99",
+        html_url: "https://github.com/crawlerbot",
+        type: "Bot",
+        name: null,
+        company: "GitHub",
+        bio: "Automation",
+        location: "CI",
+        blog: null,
+        twitter_username: null,
+        followers: 5000,
+        following: 0,
+        public_repos: 80,
+        public_gists: 0,
+        created_at: "2015-01-01T00:00:00Z",
+        updated_at: "2026-05-16T12:00:00Z",
+      });
+    }
+    if (url.pathname === "/users/crawlerbot/orgs") {
+      return Response.json([]);
+    }
+    if (url.pathname === "/users/crawlerbot/repos") {
+      return Response.json([]);
+    }
+    throw new Error(`unexpected fetch ${url.pathname}`);
+  };
+  const env = {
+    DASHBOARD_CACHE: kvStore(),
+    GITHUB_TOKEN: "shared-token",
+  };
+  try {
+    const response = await worker.fetch(
+      new Request("https://release.bar/api/users/crawlerbot/trust"),
+      env,
+      { waitUntil: () => undefined },
+    );
+    assert.equal(response.status, 200);
+    const body = (await response.json()) as TrustProfilePayload;
+    assert.equal(body.login, "crawlerbot");
+    assert.equal(body.tier, "bot");
+    assert.equal(body.score, 0);
+    assert.deepEqual(body.reasons, ["automation account"]);
   } finally {
     globalThis.fetch = originalFetch;
   }

--- a/worker/index.ts
+++ b/worker/index.ts
@@ -6562,6 +6562,7 @@ type GraphQLStargazerEdge = {
     login: string;
     avatarUrl: string;
     url: string;
+    __typename?: string;
   } | null;
 };
 
@@ -6583,6 +6584,7 @@ const repoStargazersQuery = /* GraphQL */ `
         edges {
           starredAt
           node {
+            __typename
             login
             avatarUrl
             url
@@ -6659,6 +6661,7 @@ async function recentRepoStargazersGraphql(
         login: edge.node.login,
         avatar_url: edge.node.avatarUrl,
         html_url: edge.node.url,
+        type: edge.node.__typename,
       },
     }));
 }
@@ -6801,6 +6804,7 @@ function audienceUser(
   const repos = audienceRepoSignals(insights?.repos ?? []);
   const score = calculateAudienceScore({
     login,
+    accountType: profile?.type ?? stargazer.user.type ?? null,
     followers: profile?.followers ?? 0,
     following: profile?.following ?? 0,
     publicRepos: profile?.public_repos ?? 0,
@@ -7200,6 +7204,7 @@ async function buildTrustProfile(
   }).length;
   const baseScore = calculateAudienceScore({
     login: profile.login,
+    accountType: profile.type,
     followers: profile.followers,
     following: profile.following,
     publicRepos: profile.public_repos,

--- a/worker/schemas.ts
+++ b/worker/schemas.ts
@@ -110,6 +110,7 @@ export const gitHubStargazerSchema = v.looseObject({
     login: v.string(),
     avatar_url: v.string(),
     html_url: v.string(),
+    type: v.optional(v.string()),
   }),
 });
 


### PR DESCRIPTION
Fixes #45.

## Problem

`isLikelyBot` treated any login ending in the bare string `bot` as an automation account:

```
isLikelyBot("cabot")  -> true
isLikelyBot("talbot") -> true
isLikelyBot("abbot")  -> true
```

`calculateAudienceScore` short-circuits on that, so such a user is forced to `{ score: 0, tier: "bot", reasons: ["automation account"] }`. That tier is load-bearing downstream: `worker/index.ts` filters `tier !== "bot"` out of the audience list and counts them as bots, so a real `*bot`-named stargazer is dropped from audience signals and miscounted as automation.

## Fix

Match `bot` only when it is a standalone trailing token — preceded by start-of-string or a non-letter separator (`my-bot`, `ci.bot`, `gpt4bot`, or exactly `bot`) — instead of any login that merely ends in those three letters. Real GitHub App accounts always carry the explicit `[bot]` suffix, which is still matched, as are the `bot-` infix and the `github-actions` / `dependabot` / `renovate` prefixes. The previous `-bot` case is subsumed by the new token rule.

## Tests

Added a regression test in `scripts/lib/dashboard.test.ts` covering both directions: automation (`dependabot`, `renovate`, `github-actions[bot]`, `my-bot`, `foo[bot]`, `gpt4bot`, `bot`) is still detected, and human logins (`cabot`, `talbot`, `abbot`, `wilbot`, `arbot`) are not, including that a strong profile named `cabot` is scored instead of zeroed out.

Full suite is green (154 tests), and `oxlint` / `oxfmt --check` are clean on the changed files.

## Real-run output

`isLikelyBot` against the real `audience` module.

Before the fix (current `main`), ordinary human logins are misclassified as automation:

```
human logins  -> isLikelyBot
  cabot                true
  talbot               true
  abbot                true
  wilbot               true
  arbot                true
```

After the fix, those human logins classify as human while every automation pattern still returns bot:

```
human logins  -> isLikelyBot
  cabot                false
  talbot               false
  abbot                false
  wilbot               false
  arbot                false
automation    -> isLikelyBot
  dependabot           true
  renovate             true
  github-actions[bot]  true
  my-bot               true
  foo[bot]             true
  gpt4bot              true
  bot                  true
```

Found and fixed with the help of the Claude CLI.
