### PR TITLE
chore(deps-dev): bump @types/node to 26.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
       },
       "devDependencies": {
         "@sveltejs/vite-plugin-svelte": "^7.1.2",
-        "@types/node": "^26.0.1",
+        "@types/node": "^26.1.0",
         "oxfmt": "^0.57.0",
         "oxlint": "^1.72.0",
         "svelte-check": "^4.7.1",
@@ -1232,9 +1232,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "26.0.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.0.1.tgz",
-      "integrity": "sha512-fc3KiUoBt6kie0N9bIW3E47vZsuaMf0PM2AaUpLCLT0s/LvX1nxAim6Fc049cNxODPpGm6qRAuUOB86SkRuPQw==",
+      "version": "26.1.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.0.tgz",
+      "integrity": "sha512-O0A1G3xPGy4w7AgQdAQYUlQ+BKk2Oovw8eRpofyp5KdBZULnbe+WqaOVNrm705SHphCiG4XHsACrSmPu1f+Kgw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   },
   "devDependencies": {
     "@sveltejs/vite-plugin-svelte": "^7.1.2",
-    "@types/node": "^26.0.1",
+    "@types/node": "^26.1.0",
     "oxfmt": "^0.57.0",
     "oxlint": "^1.72.0",
     "svelte-check": "^4.7.1",


### PR DESCRIPTION
## Summary

- update the Node.js type definitions from 26.0.1 to the newly published stable 26.1.0
- refresh the npm lockfile with the registry tarball and integrity for 26.1.0

## Risk

Low. This is a development-only type-definition update; runtime dependencies, application source, configuration, and generated assets are unchanged. The upstream package is maintained in DefinitelyTyped, and 26.1.0 keeps the existing `undici-types` dependency.

## Proof

- `fnm exec --using=24 npm run check:static`
  - maintained-file limit passed
  - TypeScript and Svelte diagnostics: 0 errors, 0 warnings
  - Oxlint and Oxfmt passed
  - Vite 8.1.2 production build succeeded
  - 274 tests passed, 0 failed
- `fnm exec --using=24 npm audit --json`: 0 vulnerabilities
- `fnm exec --using=24 npm audit --omit=dev --json`: 0 vulnerabilities
- `fnm exec --using=24 npm outdated --json`: no remaining direct updates
- structured Codex autoreview: clean, no accepted/actionable findings
- public model identifier gate: PASS; manifest/lockfile diff contains no model identifiers

## Upstream

- package: https://www.npmjs.com/package/@types/node/v/26.1.0
- source: https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/node

No changelog entry: development dependency maintenance only; no user-visible behavior change.
