### PR TITLE
fix(auth): keep GitHub logins alive across token expiry and KV write limits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 0.2.2 - Unreleased
 
+- Kept GitHub logins alive by storing and rotating GitHub App refresh tokens, so expiring eight-hour user access tokens renew automatically instead of silently degrading until the next login.
+- Stopped `/api/me` from rewriting the stored session and installation caches on every request and made those cache writes best-effort, so concurrent tabs (for example after a browser restart) no longer trip Workers KV write limits and render a logged-in user as logged out.
+
 ## 0.2.1 - 2026-06-19
 
 - Made anonymous GitHub actions log in first, then detect existing App installations before offering installation for uncovered dashboards.

--- a/scripts/lib/dashboard-tests/session-refresh.test.ts
+++ b/scripts/lib/dashboard-tests/session-refresh.test.ts
@@ -1,0 +1,275 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import worker from "../../../worker/index.js";
+import { kvStore, signedJson } from "../dashboard-test-harness.js";
+
+const context = { waitUntil: () => undefined };
+
+function sessionEnv(cache: ReturnType<typeof kvStore>) {
+  return {
+    AUTH_COOKIE_SECRET: "test-secret",
+    DASHBOARD_CACHE: cache,
+    GITHUB_APP_CLIENT_ID: "Iv123",
+    GITHUB_APP_CLIENT_SECRET: "client-secret",
+    GITHUB_APP_SLUG: "releasebar-app",
+  };
+}
+
+function installationPayload(id: number, login: string, type: "User" | "Organization") {
+  return {
+    id,
+    account: {
+      login,
+      type,
+      avatar_url: `https://avatars.githubusercontent.com/u/${id}`,
+      html_url: `https://github.com/${login}`,
+    },
+    html_url: `https://github.com/settings/installations/${id}`,
+    repository_selection: "all",
+    target_type: type,
+  };
+}
+
+function storedInstallation(id: number, login: string, type: "user" | "org") {
+  // Key order matches githubInstallations so unchanged lists compare equal.
+  return {
+    id,
+    accountLogin: login,
+    accountType: type,
+    accountUrl: `https://github.com/${login}`,
+    avatarUrl: `https://avatars.githubusercontent.com/u/${id}`,
+    repositorySelection: "all",
+    repositories: [],
+  };
+}
+
+const octocat = {
+  id: 1,
+  login: "octocat",
+  name: "The Octocat",
+  avatarUrl: "https://avatars.githubusercontent.com/u/1",
+  url: "https://github.com/octocat",
+};
+
+test("worker refreshes expired GitHub user tokens instead of losing them", async () => {
+  const now = Math.floor(Date.now() / 1000);
+  const sessionId = "session-refresh";
+  const cache = kvStore({
+    [`auth:session:${sessionId}`]: JSON.stringify({
+      user: octocat,
+      accessToken: "stale-token",
+      accessTokenExp: now - 10,
+      refreshToken: "refresh-1",
+      refreshTokenExp: now + 3600,
+      iat: now - 9 * 3600,
+      exp: now + 86400,
+    }),
+  });
+  const env = sessionEnv(cache);
+  const authCookie = await signedJson("test-secret", { id: sessionId, exp: now + 86400 });
+  // Rotated grants must survive a transient KV write failure (1-write/sec/key limit).
+  let failedRotationWrites = 0;
+  const basePut = cache.put.bind(cache);
+  cache.put = async (key: string, value: string) => {
+    if (key.startsWith("auth:session:") && failedRotationWrites === 0) {
+      failedRotationWrites += 1;
+      throw new Error("simulated KV write rate limit");
+    }
+    return basePut(key, value);
+  };
+
+  let refreshCalls = 0;
+  const installationTokens: string[] = [];
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (input, init) => {
+    const url = new URL(String(input));
+    if (url.hostname === "github.com" && url.pathname === "/login/oauth/access_token") {
+      const body = JSON.parse(String(init?.body ?? "{}")) as Record<string, string>;
+      assert.equal(body.grant_type, "refresh_token");
+      assert.equal(body.refresh_token, "refresh-1");
+      refreshCalls += 1;
+      return Response.json({
+        access_token: "fresh-token",
+        expires_in: 28800,
+        refresh_token: "refresh-2",
+        refresh_token_expires_in: 15552000,
+        token_type: "bearer",
+        scope: "",
+      });
+    }
+    if (url.hostname === "api.github.com" && url.pathname === "/user/installations") {
+      installationTokens.push(new Headers(init?.headers).get("authorization") ?? "");
+      return Response.json({ installations: [] });
+    }
+    throw new Error(`unexpected fetch ${url}`);
+  };
+  try {
+    const response = await worker.fetch(
+      new Request("https://release.bar/api/me", {
+        headers: { cookie: `rd_session=${authCookie}` },
+      }),
+      env,
+      context,
+    );
+    assert.equal(response.status, 200);
+    const body = (await response.json()) as { user: { login: string } | null };
+    assert.equal(body.user?.login, "octocat");
+    assert.equal(refreshCalls, 1);
+    assert.deepEqual(installationTokens, ["Bearer fresh-token"]);
+    const stored = JSON.parse((await cache.get(`auth:session:${sessionId}`)) ?? "{}") as {
+      accessToken: string;
+      accessTokenExp: number;
+      refreshToken: string;
+      refreshTokenExp: number;
+    };
+    assert.equal(stored.accessToken, "fresh-token");
+    assert.equal(stored.refreshToken, "refresh-2");
+    assert.equal(stored.accessTokenExp >= now + 28700, true);
+    assert.equal(stored.refreshTokenExp >= now + 15551900, true);
+    assert.equal(failedRotationWrites, 1);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("worker keeps sessions logged in across redundant or failing KV writes", async () => {
+  const now = Math.floor(Date.now() / 1000);
+  const sessionId = "session-write-limits";
+  const cache = kvStore({
+    [`auth:session:${sessionId}`]: JSON.stringify({
+      user: octocat,
+      accessToken: "user-token",
+      iat: now - 3600,
+      exp: now + 86400,
+      installations: [storedInstallation(77, "octocat", "user")],
+      installationsUpdatedAt: new Date((now - 3600) * 1000).toISOString(),
+    }),
+  });
+  const env = sessionEnv(cache);
+  const authCookie = await signedJson("test-secret", { id: sessionId, exp: now + 86400 });
+  const sessionPuts: string[] = [];
+  const registryPuts: string[] = [];
+  const basePut = cache.put.bind(cache);
+  cache.put = async (key: string, value: string) => {
+    if (key.startsWith("auth:session:")) {
+      sessionPuts.push(key);
+      throw new Error("simulated KV write rate limit");
+    }
+    if (key.startsWith("auth:installation:v1:")) registryPuts.push(key);
+    return basePut(key, value);
+  };
+
+  let liveInstallations = [installationPayload(77, "octocat", "User")];
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (input) => {
+    const url = new URL(String(input));
+    if (url.hostname === "api.github.com" && url.pathname === "/user/installations") {
+      return Response.json({ installations: liveInstallations });
+    }
+    throw new Error(`unexpected fetch ${url}`);
+  };
+  try {
+    const request = () =>
+      worker.fetch(
+        new Request("https://release.bar/api/me", {
+          headers: { cookie: `rd_session=${authCookie}` },
+        }),
+        env,
+        context,
+      );
+
+    // Unchanged installation list: /api/me must not rewrite the session key at all.
+    const unchanged = await request();
+    assert.equal(unchanged.status, 200);
+    const unchangedBody = (await unchanged.json()) as { user: { login: string } | null };
+    assert.equal(unchangedBody.user?.login, "octocat");
+    assert.equal(sessionPuts.length, 0);
+
+    // Changed list with a failing KV write: still logged in, write attempted once.
+    liveInstallations = [
+      installationPayload(77, "octocat", "User"),
+      installationPayload(88, "clawtopia", "Organization"),
+    ];
+    const degraded = await request();
+    assert.equal(degraded.status, 200);
+    const degradedBody = (await degraded.json()) as {
+      user: { login: string } | null;
+      installations: unknown[];
+    };
+    assert.equal(degradedBody.user?.login, "octocat");
+    assert.equal(degradedBody.installations.length, 2);
+    assert.equal(sessionPuts.length, 1);
+    // Fresh, unchanged registry entries are not rewritten on the second /api/me call.
+    assert.deepEqual(registryPuts.sort(), [
+      "auth:installation:v1:clawtopia",
+      "auth:installation:v1:octocat",
+    ]);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("worker stores refresh grants during the OAuth callback", async () => {
+  const cache = kvStore();
+  const env = sessionEnv(cache);
+  const login = await worker.fetch(
+    new Request("https://release.bar/api/auth/login?returnTo=/openclaw"),
+    env,
+    context,
+  );
+  const state = new URL(login.headers.get("location") ?? "").searchParams.get("state") ?? "";
+  const stateCookie = (login.headers.get("set-cookie") ?? "").split(";")[0] ?? "";
+
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (input) => {
+    const url = new URL(String(input));
+    if (url.hostname === "github.com" && url.pathname === "/login/oauth/access_token") {
+      return Response.json({
+        access_token: "user-token",
+        expires_in: 28800,
+        refresh_token: "refresh-1",
+        refresh_token_expires_in: 15552000,
+        token_type: "bearer",
+        scope: "",
+      });
+    }
+    if (url.hostname === "api.github.com" && url.pathname === "/user") {
+      return Response.json({
+        id: 1,
+        login: "octocat",
+        name: "The Octocat",
+        avatar_url: "https://avatars.githubusercontent.com/u/1",
+        html_url: "https://github.com/octocat",
+      });
+    }
+    if (url.hostname === "api.github.com" && url.pathname === "/user/installations") {
+      return Response.json({ installations: [] });
+    }
+    throw new Error(`unexpected fetch ${url}`);
+  };
+  try {
+    const callback = await worker.fetch(
+      new Request(
+        `https://release.bar/api/auth/callback?code=code&state=${encodeURIComponent(state)}`,
+        { headers: { cookie: stateCookie } },
+      ),
+      env,
+      context,
+    );
+    assert.equal(callback.status, 302);
+    const sessionKeys = (await cache.list({ prefix: "auth:session:" })).keys;
+    assert.equal(sessionKeys.length, 1);
+    const stored = JSON.parse((await cache.get(sessionKeys[0]?.name ?? "")) ?? "{}") as {
+      accessToken: string;
+      accessTokenExp?: number;
+      refreshToken?: string;
+      refreshTokenExp?: number;
+    };
+    assert.equal(stored.accessToken, "user-token");
+    assert.equal(typeof stored.accessTokenExp, "number");
+    assert.equal(stored.refreshToken, "refresh-1");
+    assert.equal(typeof stored.refreshTokenExp, "number");
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});

--- a/scripts/lib/dashboard.test.ts
+++ b/scripts/lib/dashboard.test.ts
@@ -14,6 +14,7 @@ import "./dashboard-tests/partial-dashboards.test.js";
 import "./dashboard-tests/scheduler-locks.test.js";
 import "./dashboard-tests/progress-consistency.test.js";
 import "./dashboard-tests/auth-installations.test.js";
+import "./dashboard-tests/session-refresh.test.js";
 import "./dashboard-tests/auth-ui.test.js";
 import "./dashboard-tests/app-quota.test.js";
 import "./dashboard-tests/profiles-auth-admin.test.js";

--- a/worker/auth-oauth.ts
+++ b/worker/auth-oauth.ts
@@ -16,6 +16,8 @@ import {
   gitHubOAuthTokenSchema,
   gitHubOAuthUserSchema,
   parseGitHubResponse,
+  safeJsonParse,
+  storedAuthSessionSchema,
 } from "./schemas.js";
 import * as v from "valibot";
 import type { GenericSchema, InferOutput } from "valibot";
@@ -39,6 +41,7 @@ import {
   sourceCoverage,
 } from "./auth-tokens.js";
 import {
+  accessTokenRefreshLeewaySeconds,
   installationAcknowledgementGraceMs,
   oauthReturnToMaxLength,
   type RequestToken,
@@ -56,45 +59,35 @@ export async function meResponse(request: Request, env: Env): Promise<Response> 
   const url = new URL(request.url);
   const record = await currentSessionRecord(request, env);
   const session = record?.session ?? null;
-  const liveInstallations = session
-    ? await githubInstallations(session.accessToken).catch(() => null)
-    : null;
-  const acknowledgedInstallations = session
-    ? fallbackInstallations(session, liveInstallations)
-    : [];
-  const installations = session
-    ? await resolvedInstallations(env, session, liveInstallations, acknowledgedInstallations)
-    : [];
-  if (record && liveInstallations && liveInstallations.length > 0) {
-    await writeSessionRecord(env, record.id, {
-      ...record.session,
-      installations,
-      installationsUpdatedAt:
-        acknowledgedInstallations.length > 0
-          ? record.session.installationsUpdatedAt
-          : new Date().toISOString(),
-    });
-  } else if (
-    record &&
-    installations.length > 0 &&
-    JSON.stringify(record.session.installations ?? []) !== JSON.stringify(installations)
-  ) {
-    await writeSessionRecord(env, record.id, {
-      ...record.session,
-      installations,
-      installationsUpdatedAt: new Date().toISOString(),
-    });
-  } else if (
-    record &&
-    liveInstallations &&
-    installations.length === 0 &&
-    (record.session.installations?.length ?? 0) > 0
-  ) {
-    await writeSessionRecord(env, record.id, {
-      ...record.session,
-      installations: [],
-      installationsUpdatedAt: new Date().toISOString(),
-    });
+  // A valid session must never look logged out because GitHub or ancillary KV
+  // cache writes hiccuped; fall back to the stored installation list instead.
+  let installations = session?.installations ?? [];
+  if (record && session) {
+    try {
+      const accessToken = await sessionAccessToken(env, record);
+      const liveInstallations = await githubInstallations(accessToken).catch(() => null);
+      const acknowledged = fallbackInstallations(session, liveInstallations);
+      installations = await resolvedInstallations(env, session, liveInstallations, acknowledged);
+      const changed = JSON.stringify(session.installations ?? []) !== JSON.stringify(installations);
+      if (changed && (liveInstallations !== null || installations.length > 0)) {
+        await bestEffortWriteSessionRecord(env, record.id, {
+          ...session,
+          installations,
+          installationsUpdatedAt:
+            liveInstallations && liveInstallations.length > 0 && acknowledged.length > 0
+              ? session.installationsUpdatedAt
+              : new Date().toISOString(),
+        });
+      }
+    } catch (error) {
+      installations = session.installations ?? [];
+      console.log(
+        JSON.stringify({
+          event: "auth_me_degraded",
+          message: error instanceof Error ? error.message : String(error),
+        }),
+      );
+    }
   }
   const coverage = session
     ? sourceCoverage(
@@ -150,7 +143,29 @@ export async function loginResponse(request: Request, env: Env): Promise<Respons
   });
 }
 
-export async function exchangeCode(url: URL, env: Env): Promise<string> {
+export type OAuthUserGrant = {
+  accessToken: string;
+  accessTokenExp?: number;
+  refreshToken?: string;
+  refreshTokenExp?: number;
+};
+
+function oauthUserGrant(
+  token: v.InferOutput<typeof gitHubOAuthTokenSchema>,
+): OAuthUserGrant | null {
+  if (!token.access_token) return null;
+  const now = Math.floor(Date.now() / 1000);
+  return {
+    accessToken: token.access_token,
+    ...(token.expires_in ? { accessTokenExp: now + token.expires_in } : {}),
+    ...(token.refresh_token ? { refreshToken: token.refresh_token } : {}),
+    ...(token.refresh_token && token.refresh_token_expires_in
+      ? { refreshTokenExp: now + token.refresh_token_expires_in }
+      : {}),
+  };
+}
+
+export async function exchangeCode(url: URL, env: Env): Promise<OAuthUserGrant> {
   const code = url.searchParams.get("code");
   if (!code) throw new Error("missing OAuth code");
   const response = await workerFetch("https://github.com/login/oauth/access_token", {
@@ -167,10 +182,37 @@ export async function exchangeCode(url: URL, env: Env): Promise<string> {
     }),
   });
   const token = parseGitHubResponse(gitHubOAuthTokenSchema, await response.json(), "oauth token");
-  if (!response.ok || !token.access_token) {
+  const grant = oauthUserGrant(token);
+  if (!response.ok || !grant) {
     throw new Error(token.error_description || token.error || "GitHub OAuth exchange failed");
   }
-  return token.access_token;
+  return grant;
+}
+
+export async function refreshedUserGrant(
+  env: Env,
+  refreshToken: string,
+): Promise<OAuthUserGrant | null> {
+  const response = await workerFetch("https://github.com/login/oauth/access_token", {
+    method: "POST",
+    headers: {
+      accept: "application/json",
+      "content-type": "application/json",
+    },
+    body: JSON.stringify({
+      client_id: env.GITHUB_APP_CLIENT_ID,
+      client_secret: env.GITHUB_APP_CLIENT_SECRET,
+      grant_type: "refresh_token",
+      refresh_token: refreshToken,
+    }),
+  });
+  if (!response.ok) return null;
+  const token = parseGitHubResponse(
+    gitHubOAuthTokenSchema,
+    await response.json(),
+    "oauth refresh token",
+  );
+  return oauthUserGrant(token);
 }
 
 export async function githubUser(accessToken: string): Promise<AuthUser> {
@@ -605,10 +647,95 @@ export async function writeSessionRecord(
   session: StoredAuthSession,
 ): Promise<void> {
   if (!id || !env.DASHBOARD_CACHE) return;
-  const ttl = Math.max(1, session.exp - Math.floor(Date.now() / 1000));
+  // KV rejects expirationTtl below 60s; a session that close to expiry is not worth rewriting.
+  const ttl = session.exp - Math.floor(Date.now() / 1000);
+  if (ttl < 60) return;
   await env.DASHBOARD_CACHE.put(`auth:session:${id}`, JSON.stringify(session), {
     expirationTtl: ttl,
   });
+}
+
+// KV allows only one write per key per second; concurrent /api/me calls (e.g. a browser
+// restart reopening several tabs) must not turn a failed rewrite into a logged-out response.
+export async function bestEffortWriteSessionRecord(
+  env: Env,
+  id: string | null,
+  session: StoredAuthSession,
+): Promise<void> {
+  try {
+    await writeSessionRecord(env, id, session);
+  } catch (error) {
+    console.log(
+      JSON.stringify({
+        event: "auth_session_write_failed",
+        message: error instanceof Error ? error.message : String(error),
+      }),
+    );
+  }
+}
+
+async function readStoredSession(env: Env, id: string): Promise<StoredAuthSession | null> {
+  const stored = await env.DASHBOARD_CACHE?.get(`auth:session:${id}`);
+  if (!stored) return null;
+  return safeJsonParse(storedAuthSessionSchema, stored, "auth session");
+}
+
+// Refresh tokens are single-use: once GitHub rotates a grant, losing the KV write would
+// strand the stored session on a spent refresh token. Retry past the 1-write/sec/key limit.
+async function persistRotatedSession(
+  env: Env,
+  id: string | null,
+  session: StoredAuthSession,
+): Promise<void> {
+  for (let attempt = 0; attempt < 3; attempt += 1) {
+    try {
+      await writeSessionRecord(env, id, session);
+      return;
+    } catch (error) {
+      if (attempt === 2) {
+        console.log(
+          JSON.stringify({
+            event: "auth_session_rotation_write_failed",
+            message: error instanceof Error ? error.message : String(error),
+          }),
+        );
+        return;
+      }
+      await new Promise((resolve) => setTimeout(resolve, 1100 * (attempt + 1)));
+    }
+  }
+}
+
+export async function sessionAccessToken(
+  env: Env,
+  record: { id: string | null; session: StoredAuthSession },
+): Promise<string> {
+  const session = record.session;
+  const now = Math.floor(Date.now() / 1000);
+  if (!session.accessTokenExp || session.accessTokenExp - now > accessTokenRefreshLeewaySeconds) {
+    return session.accessToken;
+  }
+  if (
+    !session.refreshToken ||
+    (session.refreshTokenExp !== undefined && session.refreshTokenExp <= now)
+  ) {
+    return session.accessToken;
+  }
+  const grant = await refreshedUserGrant(env, session.refreshToken).catch(() => null);
+  if (!grant) {
+    // Refresh tokens are single-use: a parallel request may have rotated first. Pick up its result.
+    const latest = record.id ? await readStoredSession(env, record.id) : null;
+    if (latest && latest.accessToken !== session.accessToken) {
+      Object.assign(session, latest);
+    }
+    return session.accessToken;
+  }
+  session.accessToken = grant.accessToken;
+  session.accessTokenExp = grant.accessTokenExp;
+  if (grant.refreshToken) session.refreshToken = grant.refreshToken;
+  if (grant.refreshTokenExp) session.refreshTokenExp = grant.refreshTokenExp;
+  await persistRotatedSession(env, record.id, session);
+  return session.accessToken;
 }
 
 export async function acknowledgedInstallations(
@@ -629,7 +756,8 @@ export async function acknowledgedInstallations(
     }
     return [];
   }
-  const liveInstallations = await githubInstallations(record.session.accessToken).catch(() => []);
+  const accessToken = await sessionAccessToken(env, record);
+  const liveInstallations = await githubInstallations(accessToken).catch(() => []);
   if (
     installationId &&
     !liveInstallations.some((installation) => installation.id === installationId)
@@ -644,7 +772,7 @@ export async function acknowledgedInstallations(
     ...acknowledged,
   ]);
   await writeInstallationRegistry(env, installations);
-  await writeSessionRecord(env, record.id, {
+  await bestEffortWriteSessionRecord(env, record.id, {
     ...record.session,
     installations,
     installationsUpdatedAt: new Date().toISOString(),

--- a/worker/auth-tokens.ts
+++ b/worker/auth-tokens.ts
@@ -19,6 +19,7 @@ import {
   authCookie,
   cookie,
   currentSession,
+  currentSessionRecord,
   installReturnCookieValue,
   oauthStateBinding,
   oauthStateCookieName,
@@ -41,6 +42,7 @@ import {
   isAdminLogin,
   loginResponse,
   resolvedInstallations,
+  sessionAccessToken,
 } from "./auth-oauth.js";
 import {
   type AuthSession,
@@ -269,13 +271,14 @@ export async function requestInstallationToken(
   signal?: AbortSignal,
 ): Promise<RequestToken | null> {
   if (!appTokenConfigured(env)) return null;
-  const session = await currentSession(request, env);
-  if (!session) return null;
+  const record = await currentSessionRecord(request, env);
+  if (!record) return null;
+  const accessToken = await sessionAccessToken(env, record);
   const liveInstallations =
-    (await nullOnNonAbortError(githubInstallations(session.accessToken, signal))) ?? null;
+    (await nullOnNonAbortError(githubInstallations(accessToken, signal))) ?? null;
   const installations = await resolvedInstallations(
     env,
-    session,
+    record.session,
     liveInstallations,
     undefined,
     signal,
@@ -494,17 +497,23 @@ export async function callbackResponse(
       throw new Error("invalid OAuth state");
     }
     validatedState = true;
-    const accessToken = await exchangeCode(url, env);
-    const user = await githubUser(accessToken);
+    const grant = await exchangeCode(url, env);
+    const user = await githubUser(grant.accessToken);
     const now = Math.floor(Date.now() / 1000);
     const session: StoredAuthSession = {
       user,
-      accessToken,
+      accessToken: grant.accessToken,
+      ...(grant.accessTokenExp !== undefined ? { accessTokenExp: grant.accessTokenExp } : {}),
+      ...(grant.refreshToken ? { refreshToken: grant.refreshToken } : {}),
+      ...(grant.refreshTokenExp !== undefined ? { refreshTokenExp: grant.refreshTokenExp } : {}),
       iat: now,
       exp: now + sessionMaxAgeSeconds,
     };
-    const liveInstallations = await githubInstallations(accessToken).catch(() => null);
-    const installations = await resolvedInstallations(env, session, liveInstallations);
+    const liveInstallations = await githubInstallations(grant.accessToken).catch(() => null);
+    // Login must not fail because installation cache writes hit KV write limits.
+    const installations = await resolvedInstallations(env, session, liveInstallations).catch(
+      () => liveInstallations ?? [],
+    );
     if (installations.length > 0) {
       session.installations = installations;
       session.installationsUpdatedAt = new Date().toISOString();

--- a/worker/config.ts
+++ b/worker/config.ts
@@ -158,6 +158,7 @@ export const sessionCookie = "rd_session";
 export const installReturnCookie = "rd_install_return";
 export const oauthStateCookiePrefix = "rd_oauth_state_";
 export const sessionMaxAgeSeconds = 30 * 24 * 60 * 60;
+export const accessTokenRefreshLeewaySeconds = 5 * 60;
 export const stateMaxAgeSeconds = 10 * 60;
 export const oauthReturnToMaxLength = 1024;
 export const buildPending = Symbol("build-pending");
@@ -341,6 +342,9 @@ export type AuthSession = {
 export type StoredAuthSession = {
   user: AuthUser;
   accessToken: string;
+  accessTokenExp?: number;
+  refreshToken?: string;
+  refreshTokenExp?: number;
   iat: number;
   exp: number;
   installations?: AuthInstallation[];

--- a/worker/installation-registry.ts
+++ b/worker/installation-registry.ts
@@ -106,14 +106,41 @@ export async function installationRefreshTargetInput(
   };
 }
 
+// Skip rewrites of registry entries that already hold the same content and were
+// refreshed recently, so bursts of /api/me calls (multiple tabs, browser restart)
+// stay under Workers KV's one-write-per-key-per-second limit.
+const installationRegistryRewriteMinAgeMs = 5 * 60 * 1000;
+
+async function installationRegistryEntryFresh(
+  env: Env,
+  installation: StoredInstallationRecord,
+): Promise<boolean> {
+  const existing = await readInstallationRegistry(env, installation.accountLogin).catch(() => null);
+  if (!existing) return false;
+  const updatedAt = Date.parse(existing.updatedAt ?? "");
+  if (!Number.isFinite(updatedAt) || Date.now() - updatedAt > installationRegistryRewriteMinAgeMs) {
+    return false;
+  }
+  const { updatedAt: _existingUpdatedAt, ...existingContent } = existing;
+  const { updatedAt: _nextUpdatedAt, ...nextContent } = installation;
+  return JSON.stringify(existingContent) === JSON.stringify(nextContent);
+}
+
 export async function writeInstallationRegistry(
   env: Env,
   installations: AuthInstallation[],
 ): Promise<void> {
   if (!env.DASHBOARD_CACHE) return;
   const normalized = installations.map(normalizedInstallation);
+  const stale = (
+    await Promise.all(
+      normalized.map(async (installation) =>
+        (await installationRegistryEntryFresh(env, installation)) ? null : installation,
+      ),
+    )
+  ).filter((installation): installation is StoredInstallationRecord => installation !== null);
   await Promise.all(
-    normalized.map((installation) => {
+    stale.map((installation) => {
       return env.DASHBOARD_CACHE!.put(
         installationRegistryKey(installation.accountLogin),
         JSON.stringify(installation),
@@ -122,7 +149,7 @@ export async function writeInstallationRegistry(
     }),
   );
   await Promise.all(
-    normalized
+    stale
       .filter((installation) => installation.repositorySelection === "all")
       .map(async (installation) => {
         const input = await installationRefreshTargetInput(env, installation.accountLogin);

--- a/worker/schemas.ts
+++ b/worker/schemas.ts
@@ -2,6 +2,9 @@ import * as v from "valibot";
 
 export const gitHubOAuthTokenSchema = v.looseObject({
   access_token: v.optional(v.string()),
+  expires_in: v.optional(v.number()),
+  refresh_token: v.optional(v.string()),
+  refresh_token_expires_in: v.optional(v.number()),
   error: v.optional(v.string()),
   error_description: v.optional(v.string()),
 });
@@ -266,6 +269,9 @@ const authInstallationSchema = v.object({
 export const storedAuthSessionSchema = v.object({
   user: authUserSchema,
   accessToken: v.string(),
+  accessTokenExp: v.optional(v.number()),
+  refreshToken: v.optional(v.string()),
+  refreshTokenExp: v.optional(v.number()),
   iat: v.number(),
   exp: v.number(),
   installations: v.optional(v.array(authInstallationSchema)),


### PR DESCRIPTION
## Problem

Logins on release.bar were dropping far earlier than the 30-day session lifetime ("logged out after a restart or so"). Two mechanisms:

1. **GitHub user access tokens were lost after ~8 hours.** GitHub App user tokens expire (default 8h) and come with a rotating refresh token, but the OAuth exchange discarded `refresh_token`/`expires_in`. Once the stored token expired, live installation lookups silently failed until the next manual login.
2. **`/api/me` could 500 under concurrent load and render a valid session as logged out.** Every `/api/me` call rewrote the session KV key and the installation registry keys unconditionally. Workers KV allows one write per key per second, so concurrent tabs (e.g. a browser restart reopening several tabs) tripped the limit; the unhandled write error turned `/api/me` into a 500, which the frontend renders as logged out.

## Fix

- Store `accessTokenExp`, `refreshToken`, and `refreshTokenExp` in the session and refresh the user token before GitHub calls when it is near expiry; rotated grants are persisted with retries since refresh tokens are single-use.
- Guard `/api/me` session rewrites behind change detection and make them best-effort; a valid session never looks logged out because an ancillary cache write failed.
- Skip installation-registry rewrites when the entry is unchanged and was refreshed within the last 5 minutes; login callback no longer fails on registry write errors.
- Skip session rewrites within the final minute before expiry instead of sending KV an invalid `expirationTtl`.

## Tests

- New `session-refresh.test.ts`: token refresh + rotation persistence across a failing KV write, no rewrite for unchanged installations, `/api/me` stays 200 (and logged in) when the session write fails, registry dedup, and callback persistence of refresh grants.
- `npm run check:static` green (typecheck, lint, format, build, size, 277 tests).
- Codex autoreview clean after addressing rotation-durability and registry-write findings.
