### PR TITLE
build: refresh Cloudflare compatibility date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.2.3 - Unreleased
 
 - Refreshed the dashboard design: the UI now ships JetBrains Mono (previously only used for social cards), uppercase micro-labels gained consistent letterspaced styling, dashboard rows show a freshness-colored edge bar and a freshness-tinted state tag, missing commit counts render quietly instead of as large red `n/a`, active filters/periods glow green, big numerals got heavier weights with a subtle phosphor glow, dark mode gained faint CRT scanlines, and the light theme received matching contrast and polish.
+- Refreshed the Cloudflare Workers compatibility date after verifying the newly enabled TLS option validation does not affect ReleaseBar.
 
 ## 0.2.2 - 2026-07-04
 

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,6 +1,6 @@
 name = "releasedeck-api"
 main = "node_modules/.cache/releasebar-build/worker/index.js"
-compatibility_date = "2026-06-12"
+compatibility_date = "2026-07-11"
 account_id = "de09342a728de2c25c85cc6b34d68739"
 workers_dev = true
 


### PR DESCRIPTION
## Summary

- advance the Cloudflare Workers compatibility date from `2026-06-12` to `2026-07-11`
- document the runtime maintenance in the unreleased changelog

## Compatibility

Cloudflare recommends periodically advancing compatibility dates after reviewing intervening flags. The only new default after ReleaseBar's previous date is stricter validation for unsupported TLS options on `2026-06-16`; ReleaseBar does not import or use the TLS APIs or options affected by that flag.

Official sources:

- https://developers.cloudflare.com/workers/configuration/compatibility-dates/
- https://developers.cloudflare.com/workers/configuration/compatibility-flags/
- https://developers.cloudflare.com/workers/best-practices/workers-best-practices/

## Proof

Exact candidate: `0a42aff7332d8fa72024f2b14b3ad13fa8397a1e`

- `npm ci` — passed; lockfile install clean
- `npm audit --omit=dev` — 0 vulnerabilities
- `npm run check` — passed: size gate, typecheck, 0 Svelte diagnostics, lint, formatting, production builds, 277/277 tests, and real-data check across 139 repositories with 83 released projects
- `npm exec --yes --package wrangler -- wrangler deploy --dry-run` — passed with Wrangler 4.110.0 and the updated checked-in configuration
- `npm run dev:worker` — local production-shaped Worker returned HTTP 200 for `/`, `/steipete`, `/openclaw/openclaw`, and `/api/_discover`; discovery returned 40 projects with honest `partial` cache state while hydration continued
- structured Codex autoreview — clean; no accepted/actionable findings
- Public Model Identifier Gate — PASS; the exact candidate is not model-bearing and introduces no model identifiers

Risk is low: two files, +2/-1; no application code, dependency, binding, deployment, or release change.