### PR TITLE
docs: rewrite README to house standard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 0.2.4 - Unreleased
 
+- Reworked the README into a concise product and quick-start guide, with detailed behavior and self-hosting operations moved into focused docs.
+
 ## 0.2.3 - 2026-08-01
 
 - Refreshed the dashboard design: the UI now ships JetBrains Mono (previously only used for social cards), uppercase micro-labels gained consistent letterspaced styling, dashboard rows show a freshness-colored edge bar and a freshness-tinted state tag, missing commit counts render quietly instead of as large red `n/a`, active filters/periods glow green, big numerals got heavier weights with a subtle phosphor glow, dark mode gained faint CRT scanlines, and the light theme received matching contrast and polish.

--- a/README.md
+++ b/README.md
@@ -1,136 +1,79 @@
-# 📦 ReleaseBar
+# ReleaseBar 📦 — Know what needs a release.
 
-Release freshness dashboard for public GitHub users and orgs.
+[![CI](https://img.shields.io/github/actions/workflow/status/steipete/ReleaseBar/ci.yml?branch=main&style=flat-square&label=ci)](https://github.com/steipete/ReleaseBar/actions/workflows/ci.yml)
+[![GitHub release](https://img.shields.io/github/v/release/steipete/ReleaseBar?style=flat-square&label=release)](https://github.com/steipete/ReleaseBar/releases/latest)
+[![Node.js](https://img.shields.io/badge/node-%3E%3D22.12-339933?style=flat-square&logo=node.js&logoColor=white)](package.json)
+[![License](https://img.shields.io/github/license/steipete/ReleaseBar?style=flat-square)](LICENSE)
+[![Live](https://img.shields.io/badge/live-release.bar-6fda44?style=flat-square)](https://release.bar)
 
-ReleaseBar tracks public GitHub repository release health: latest version, release date, commits since release, activity, stars, language, topics, open work, CI status, and recent stargazer audience signals. It serves cached dashboards for routes like `https://release.bar/steipete`, `https://release.bar/openclaw`, and `https://release.bar/microsoft`.
+ReleaseBar is a release-freshness dashboard for public GitHub users and organizations. It combines releases, unreleased commits, repository activity, CI, and open work so maintainers can see which projects need attention.
 
-Owner dashboards show visible public repositories immediately with lightweight repo metadata, then progressively hydrate release, commit, PR, and CI data in the background.
+## Install
 
-See [VISION.md](VISION.md) for the durable product principles and boundaries behind those choices.
+The public service runs at [release.bar](https://release.bar), with no installation required.
 
-## Configure
-
-Edit `releasebar.config.json`:
-
-- `owners`: GitHub users or orgs to scan
-- `includeForks`: include forked repositories
-- `includeArchived`: include archived repositories
-- `includeUnreleased`: include repositories without GitHub releases in static builds
-- `excludeRepos`: full `owner/name` entries to hide
-- `canonicalDomain`: primary public dashboard domain
-
-## Build
+To run the source locally:
 
 ```sh
-npm run build
+git clone https://github.com/steipete/ReleaseBar.git
+cd ReleaseBar
+npm ci
 ```
 
-Set `GITHUB_TOKEN` for higher API limits. GitHub Actions uses the built-in token. Static builds read `releasebar.config.json`; the public service reads owner routes through the Worker API.
+ReleaseBar requires Node.js 22.12 or newer. Node.js 24 is the version used by CI.
 
-## Generic Dashboards
+## Quick start
 
-- `/` loads `ReleaseBar Hot`, a cached board built from recently requested public dashboards
-- `/:owner` loads the Worker API for that owner
-- `/:owner/activity` groups day, week, or month public work by repository, ranked by activity volume, with AI summaries and contributor forks of profile-owned repositories omitted when GitHub identifies them
-- query options: `forks=true`, `archived=true`, `unreleased=false`
-- add public sources with `owners=openclaw,steipete` or `repos=owner/name`
-- the settings panel can add public users, orgs, or explicit repos to the current URL
-- signed-in dashboard owners can save added public sources and local visibility as the public default for their clean owner route
-- custom URLs are capped at 8 added public sources
-- settings can hide visible owners or repos locally without changing the shared cache
-- GitHub App login uses `/api/auth/login`, `/api/auth/callback`, `/api/auth/install`, `/api/auth/logout`, and `/api/me`
-- `Log in with GitHub` signs the user in, detects existing GitHub App installations, and only offers installation when the current dashboard source is not covered
-- GitHub App installation gives ReleaseBar dedicated GitHub API quota for the selected account/repositories; public unsynced dashboards stay metadata-only and skip release hydration
-- repository audience backfill is GitHub App-only and warms bounded week/month stargazer trust caches for covered repositories
-- once an account installation is known, public refreshes for that account can use its app quota even for anonymous viewers; mixed-owner dashboards partition work across each source account's installation instead of forcing the whole dashboard onto shared quota
-- successful login or installation immediately queues a bounded public owner-dashboard warm for each all-repository installation when its shared cache is missing, stale, or incomplete
-- private repositories are ignored even when selected in GitHub App installation; ReleaseBar only stores and renders public repository metadata
-- the need-attention metric filters repos with unreleased commits, stale releases, failing/cancelled CI, or issue/PR pressure and rows show the reason inline
-- owner pages show bounded people trust or org signal profiles with GitHub age, reach, footprint, safety dimensions, weighted score factors, and recent repository evidence
-- repository detail pages include release cadence, recent releases, contributors, languages, commit/churn charts, recent public stargazer audience signals, and 30-day issue/PR trend counts when GitHub provides them
-- repository detail pages can show an AI summary of commit titles since the latest release when the Worker has an OpenAI API key
-
-## API And Cache
-
-The Worker in `worker/index.ts` serves both the static app shell and the generic owner API. See [docs/api.md](docs/api.md) for the public REST contract, response shapes, cache semantics, and agent PR-triage guidance.
-
-- `GET /api/:owner` returns a cached dashboard for a public GitHub user or org
-- `GET /api/:owner/events` streams cache updates for progressive rebuilds
-- `GET /api/:owner/activity?range=day|week|month` returns ranked, grouped public activity and cached AI summaries
-- `GET /api/users/:login/trust` returns cached public people trust or organization signal scoring, account age, score dimensions, and weighted score factors for one GitHub profile
-- `GET /api/repos/:owner/:repo` returns repository detail stats
-- `GET /api/repos/:owner/:repo/audience?range=week|month` returns cached recent stargazer scoring from public GitHub profile fields
-- `POST /api/repos/:owner/:repo/audience/backfill` warms bounded week/month stargazer trust caches with GitHub App quota only
-- `GET /openapi.json`, `GET /api/openapi.json`, and `GET /api/swagger.json` expose the public API as Swagger-compatible OpenAPI 3.1 JSON
-- `GET /api/_discover` and `GET /api/_hot` power the root dashboard
-
-Dashboard builds validate public GitHub owners and scan up to the 200 most recently pushed public repositories per owner. Shared owner metadata snapshots feed every dashboard filter/release variant. Active owners get a lean issue/PR/archive GraphQL refresh about every 15 minutes, while release and CI hydration stays on the roughly six-hour dashboard cadence. Cold dashboards return lightweight repository metadata before release hydration continues through Cloudflare Queue in 12-repository batches, with up to four repositories hydrated concurrently inside each batch. Anonymous REST fallbacks leave split counts unavailable instead of spending one extra request per repository. Unsynced public dashboards show bounded repository metadata without release, compare, commit, or check-run calls. Dashboard payloads expose separate `countsUpdatedAt`, `releasesUpdatedAt`, and `ciUpdatedAt` cache timestamps. Dashboard payloads, owner snapshots, repo fragments, hot boards, app-installation coverage, profile settings, and auth session data live in Cloudflare KV. A Durable Object binding (`DASHBOARD_LOCKS`) prevents repeated cold requests from stampeding GitHub and stores strongly consistent progressive-scan checkpoints, active-job reservations, and refresh-target failure state between rapid Queue deliveries.
-
-Fresh dashboard cache is served for about 1h. Stale or partial cache is shown while a background rebuild continues, so large owners can show useful rows before all release data finishes. Dashboard records are retained longer than the fresh window so older public data can remain visible during GitHub outages or rate limits, with the UI marking stale/partial state.
-
-`GITHUB_TOKEN` is the shared fallback bucket for sources without GitHub App coverage. Repository detail caches use conditional ETag revalidation, concurrent cold requests share one build, and signed webhooks evict repository-scoped cache fragments. When the shared core or GraphQL bucket falls below 2,000 remaining requests, nonessential contributor, language, stats, and work-trend enrichment is deferred. Below 1,000 remaining requests, uncached repository detail becomes cache-only until reset; installed accounts continue on their independent App buckets.
-
-The Worker writes structured `github_token_use` and `github_installation_token` logs without token values. Use Cloudflare Worker tail/logs to audit which area, route, quota source, account, status, and remaining rate-limit bucket handled public GitHub requests.
-
-### GitHub App Login
-
-Configure these Worker secrets before enabling login:
-
-- `GITHUB_APP_CLIENT_ID`
-- `GITHUB_APP_CLIENT_SECRET`
-- `GITHUB_APP_ID`
-- `GITHUB_APP_PRIVATE_KEY`
-- `GITHUB_WEBHOOK_SECRET`
-- `AUTH_COOKIE_SECRET`
-
-`GITHUB_APP_ID` and `GITHUB_APP_PRIVATE_KEY` are required for dedicated GitHub App quota. Without them, users can still sign in, but dashboard rebuilds use the shared server token/cache. Optional: `GITHUB_APP_SLUG` defaults to `releasebar-app`, the current GitHub App slug.
-
-Set the GitHub App setup URL to `https://release.bar/api/auth/install` and enable redirect-on-update so users return to their dashboard after installing or changing repository access.
-
-Set the GitHub App webhook URL to `https://release.bar/api/github/webhook`, use the same value as the `GITHUB_WEBHOOK_SECRET` Worker secret, and subscribe to `Issues`, `Pull requests`, `Push`, `Releases`, and `Repository` events. Signed deliveries up to 2 MiB enter Cloudflare Queue before acknowledgement. Per-owner Durable Objects coalesce issue/PR bursts into one authoritative repository-count refresh and push/release bursts into one release refresh; repository privacy and archive transitions remain distinct and use repository observation clocks. Up to 25 recently viewed matching candidates from the available target indexes enter an immediate batch; fanout waits for that batch to drain, capped at two minutes, before the remaining recent variants follow through a stable key-ordered sweep. Older variants refresh on demand.
-
-### AI Release Summaries
-
-Configure `OPENAI_API_KEY` as a Worker secret to summarize recent public activity and commit titles since the latest release. Optional: `OPENAI_SUMMARY_MODEL` defaults to `chat-latest`, OpenAI's GPT-5.5 Instant API alias.
+Open a dashboard for any public GitHub owner, such as [release.bar/steipete](https://release.bar/steipete), or read the same cached data from the API:
 
 ```sh
-wrangler secret put OPENAI_API_KEY
+curl -fsSL https://release.bar/api/steipete \
+  | jq '{owners: [.owners[].login], repositories: (.projects | length), cache: .cache.state}'
 ```
 
-Summaries are generated server-side through the OpenAI Responses API without an explicit reasoning option. Owner activity uses one compact structured request for the overall summary and up to 30 repository summaries, with a repository-aware output ceiling and a compatibility floor for configurable reasoning models. Release summaries are cached by repository, release tag, default-branch head SHA, model, and prompt version; activity summaries also refresh when the configured model changes.
+The response may initially report `partial` or `stale` while deeper release and CI data hydrates in the background.
 
-## Local Real-Data Testing
+## Dashboards
 
-Use Wrangler remote dev when you need local code with real Cloudflare execution, GitHub App secrets, and OpenAI/GitHub tokens:
+| Route              | Shows                                                                                   |
+| ------------------ | --------------------------------------------------------------------------------------- |
+| `/`                | Recently requested public dashboards                                                    |
+| `/:owner`          | Release health for one GitHub user or organization                                      |
+| `/:owner/activity` | Day, week, or month public activity grouped by repository                               |
+| `/:owner/:repo`    | Release cadence, contributors, languages, churn, open work, and recent audience signals |
+
+Dashboard settings can add public owners, organizations, or explicit repositories to the current URL. Query parameters cover shareable filters such as `forks=true`, `archived=true`, `unreleased=false`, `owners=openclaw,steipete`, and `repos=owner/name`.
+
+See the [product guide](docs/product-guide.md) for login, GitHub App, filtering, attention, trust, and repository-detail behavior.
+
+## Freshness and public data
+
+Owner dashboards return lightweight public repository metadata first, then hydrate release, commit, pull-request, and CI data in bounded background batches. Cached data remains visible during GitHub outages or rate limits, and each payload reports whether its data is fresh, stale, partial, warming, or errored.
+
+ReleaseBar ignores private repositories even when a GitHub App installation includes them. Installing the app supplies dedicated GitHub API quota for covered public sources; it does not turn ReleaseBar into a private-repository browser or a GitHub write proxy.
+
+## API
+
+The Worker exposes cached public endpoints for owner dashboards, activity, repository details, audience signals, and public GitHub profile context. Swagger-compatible OpenAPI 3.1 is available at [`/openapi.json`](https://release.bar/openapi.json).
+
+See the [public API reference](docs/api.md) for response shapes, cache semantics, and agent guidance. The [refresh scheduler](docs/refresh-scheduler.md) describes background hydration, retries, quota selection, and webhook-driven refreshes.
+
+## Self-hosting
+
+Static builds use `releasebar.config.json`; the hosted service serves arbitrary public owner routes through the Cloudflare Worker API. See [Self-hosting and operations](docs/self-hosting.md) for configuration, local Worker modes, GitHub App setup, optional AI summaries, Cloudflare bindings, and deployment checks.
+
+## Development
 
 ```sh
-npm run dev:worker:real
-```
-
-Open `http://localhost:8787/steipete` or any other route. This runs the current checkout on Cloudflare, so cold dashboards can use the same GitHub App credentials and real API paths as `release.bar`.
-
-For frontend hot reload, run both processes:
-
-```sh
+npm ci
+npm run check:static
 npm run dev
-npm run dev:worker:real
 ```
 
-The Vite app falls back to `http://127.0.0.1:8787` for API calls. `npm run dev:worker` stays fully local and is useful for UI shape and tests, but it does not have production secrets unless you provide local `.dev.vars`.
+The Vite development server runs on `http://127.0.0.1:5173`. Run `npm run dev:worker` alongside it when testing Worker API routes locally.
 
-Because `wrangler.toml` defines a KV `preview_id`, remote dev uses the preview KV namespace instead of the production cache. It can fetch real data and warm that preview cache without mutating the live `release.bar` cache.
+Product direction and boundaries live in [VISION.md](VISION.md).
 
-## Deploy
+## License
 
-The combined app/API Worker deploys with Wrangler through `.github/workflows/deploy.yml` on pushes to `main`:
-
-```sh
-npm run build
-wrangler deploy
-```
-
-`wrangler.toml` binds `dist` as Worker static assets, `DASHBOARD_CACHE` as KV, and `DASHBOARD_LOCKS` as the Durable Object single-flight lock. The Worker runs first so `/api/*` stays dynamic and owner routes like `/openclaw` return the app shell with HTTP 200. Deploy CI smokes the root page, an owner page, a repository detail page, the discovery API, and live JS/CSS asset hashes after Wrangler deploys.
-
-`.github/workflows/monitor.yml` repeats the production route, discovery API, and live asset smoke checks every six hours without redeploying unchanged code.
-
-The deployed Worker service is still named `releasedeck-api` in Cloudflare for continuity. The canonical product, repo, package, and config names are ReleaseBar / `releasebar`.
+MIT. See [LICENSE](LICENSE).

--- a/docs/product-guide.md
+++ b/docs/product-guide.md
@@ -1,0 +1,44 @@
+# ReleaseBar Product Guide
+
+ReleaseBar presents release health for public GitHub users, organizations, and repositories. This guide covers the dashboard behavior that is intentionally summarized in the README.
+
+## Dashboard routes
+
+- `/` loads ReleaseBar Hot, a cached board built from recently requested public dashboards.
+- `/:owner` loads the Worker API for a public GitHub user or organization.
+- `/:owner/activity` groups day, week, or month public work by repository and ranks repositories by activity volume. Contributor forks of profile-owned repositories are omitted when GitHub identifies them; unrelated external project work remains visible.
+- `/:owner/:repo` shows release cadence, recent releases, contributors, languages, commit and churn charts, public stargazer audience signals, and 30-day issue and pull-request trends when GitHub provides them.
+
+## Custom dashboards
+
+The settings panel can add public users, organizations, or explicit repositories to the current URL. Shareable query options include:
+
+- `forks=true` to include forks
+- `archived=true` to include archived repositories
+- `unreleased=false` to hide repositories without a GitHub release
+- `owners=openclaw,steipete` to add public owners
+- `repos=owner/name` to add explicit public repositories
+
+Custom URLs accept up to eight added public sources. Settings can hide visible owners or repositories locally without changing the shared cache. Signed-in dashboard owners can save added sources and local visibility as the public default for their clean owner route.
+
+## Attention and repository context
+
+The need-attention metric identifies repositories with unreleased commits, stale releases, failing or cancelled CI, or issue and pull-request pressure. Rows include the reason for the state instead of exposing only a score.
+
+Owner pages show bounded people-trust or organization-signal profiles based on public GitHub age, reach, footprint, safety dimensions, weighted factors, and recent repository evidence. These signals are context, not identity or access-control decisions. Repository pages can also show bounded recent public stargazer signals and, when configured, an AI summary of commit titles since the latest release.
+
+## GitHub login and installation
+
+GitHub authentication uses `/api/auth/login`, `/api/auth/callback`, `/api/auth/install`, `/api/auth/logout`, and `/api/me`. Login detects existing ReleaseBar GitHub App installations and offers installation when the current dashboard source is not covered.
+
+An installation supplies dedicated GitHub API quota for the selected account and public repositories. Public unsynced dashboards remain metadata-only and skip release hydration. Once an installation is known, anonymous viewers can benefit from that account's app quota; mixed-owner dashboards partition work across each covered source instead of consuming one shared quota bucket.
+
+Successful login or installation queues a bounded warm-up for an all-repository installation when its shared owner dashboard is missing, stale, or incomplete. Audience backfill is GitHub App-only and warms bounded week and month stargazer-signal caches for covered public repositories.
+
+Private repositories are ignored even when selected in the installation. ReleaseBar stores and renders public repository metadata only.
+
+## Freshness behavior
+
+Dashboard builds validate public GitHub owners and scan up to the 200 most recently pushed public repositories per owner. Lightweight metadata appears before release and CI hydration completes. Active owner issue and pull-request counts refresh more frequently than deeper release data.
+
+Fresh cache is served for about one hour. Stale or partial cache stays visible while a bounded background rebuild continues, and payloads expose separate timestamps for count, release, and CI data. The [public API reference](api.md) defines these cache fields; the [refresh scheduler](refresh-scheduler.md) documents batching, retries, quota selection, and webhook fanout.

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -1,0 +1,111 @@
+# Self-hosting and Operations
+
+ReleaseBar is a Svelte frontend and Cloudflare Worker service. The Worker serves the static app shell and public GitHub API routes, while Cloudflare KV, Queues, and a Durable Object coordinate cached dashboard hydration.
+
+## Requirements
+
+- Node.js 22.12 or newer; CI and `.nvmrc` use Node.js 24.
+- npm, using the committed `package-lock.json`.
+- A Cloudflare account and Wrangler authentication for remote development or deployment.
+- A GitHub token for higher API limits when building real dashboard data locally.
+
+Install dependencies and build the app:
+
+```sh
+npm ci
+npm run build
+```
+
+`GITHUB_TOKEN` is optional. GitHub Actions uses its built-in token for data builds that need authenticated GitHub access.
+
+## Configuration
+
+Static builds read `releasebar.config.json`.
+
+| Key                 | Purpose                                                       |
+| ------------------- | ------------------------------------------------------------- |
+| `owners`            | GitHub users or organizations to scan                         |
+| `includeForks`      | Include forked repositories                                   |
+| `includeArchived`   | Include archived repositories                                 |
+| `includeUnreleased` | Include repositories without GitHub releases in static builds |
+| `excludeRepos`      | Hide specific `owner/name` repositories                       |
+| `canonicalDomain`   | Set the primary dashboard domain                              |
+
+The public Worker service accepts arbitrary public owners through route and query parameters rather than limiting requests to the static configuration.
+
+## Local development
+
+For frontend hot reload:
+
+```sh
+npm run dev
+```
+
+For a fully local Worker on port 8787:
+
+```sh
+npm run dev:worker
+```
+
+The Vite app falls back to `http://127.0.0.1:8787` for API calls. Local Worker development does not receive production secrets unless they are provided through local Wrangler configuration.
+
+For local code running on Cloudflare with real secrets and preview KV:
+
+```sh
+npm run dev:worker:real
+```
+
+Open `http://localhost:8787/steipete` or another owner route. Because `wrangler.toml` defines a KV `preview_id`, remote development warms preview storage rather than the production dashboard cache.
+
+## Cloudflare resources
+
+`wrangler.toml` binds:
+
+- `dist` as Worker static assets
+- `DASHBOARD_CACHE` as KV storage for dashboard, repository, settings, installation, session, and scheduler records
+- `DASHBOARD_LOCKS` as a Durable Object for single-flight builds, checkpoints, job reservations, and failure state
+- `REFRESH_QUEUE` for bounded background hydration and webhook work
+
+The Worker runs before static assets so `/api/*` stays dynamic and owner routes return the application shell. The deployed Cloudflare service remains named `releasedeck-api` for infrastructure continuity even though the product, repository, package, and configuration names are ReleaseBar and `releasebar`.
+
+The shared `GITHUB_TOKEN` is the fallback quota bucket for sources without GitHub App coverage. Installed accounts use their own App quota. ReleaseBar defers optional enrichment before core release-health work when shared GitHub quota becomes constrained. Detailed cache, queue, and retry behavior is in [the refresh scheduler](refresh-scheduler.md).
+
+## GitHub App
+
+Configure these Worker secrets to enable login and installation:
+
+- `GITHUB_APP_CLIENT_ID`
+- `GITHUB_APP_CLIENT_SECRET`
+- `GITHUB_APP_ID`
+- `GITHUB_APP_PRIVATE_KEY`
+- `GITHUB_WEBHOOK_SECRET`
+- `AUTH_COOKIE_SECRET`
+
+`GITHUB_APP_ID` and `GITHUB_APP_PRIVATE_KEY` enable dedicated installation quota. Without them, users can still sign in, but dashboard rebuilds use the shared server token and cache. `GITHUB_APP_SLUG` is optional and defaults to `releasebar-app`.
+
+Set the GitHub App setup URL to `https://release.bar/api/auth/install` and enable redirect-on-update. Set the webhook URL to `https://release.bar/api/github/webhook`, use the same webhook secret in GitHub and Cloudflare, and subscribe to Issues, Pull requests, Push, Releases, and Repository events.
+
+Signed webhook payloads up to 2 MiB enter Cloudflare Queue before acknowledgement. Issue and pull-request bursts coalesce into authoritative count refreshes; push and release bursts coalesce into release refreshes. Privacy and archive transitions remain separate so visibility changes apply promptly.
+
+## AI summaries
+
+Set `OPENAI_API_KEY` as a Worker secret to summarize public owner activity and commit titles since the latest release:
+
+```sh
+wrangler secret put OPENAI_API_KEY
+```
+
+`OPENAI_SUMMARY_MODEL` is optional and defaults to `chat-latest`. Summaries run server-side through the OpenAI Responses API, remain subordinate to public source data, and are cached with the model and prompt version.
+
+## Deploy
+
+The production deployment is a Cloudflare Worker with Worker Assets, not GitHub Pages. A local deployment runs:
+
+```sh
+npm run build
+wrangler deploy
+```
+
+Pushes to `main` run `.github/workflows/deploy.yml`. The workflow requires `CLOUDFLARE_API_TOKEN`, runs `npm run check:static`, deploys through Wrangler, compares live JavaScript and CSS asset hashes with the local build, and smokes `/`, `/steipete`, `/openclaw/openclaw`, and `/api/_discover`.
+
+`.github/workflows/monitor.yml` repeats the production route, discovery API, and asset checks every six hours without redeploying unchanged code.


### PR DESCRIPTION
## Summary

Before, the 136-line README mixed the product introduction with an exhaustive dashboard inventory, cache internals, GitHub App configuration, remote testing, and deployment operations. After, the 79-line README follows the house standard: dynamic badges, the hosted path first, a live 60-second API quick start, progressively deeper product/API/self-hosting links, development, and license.

## Content movement

- Moved detailed dashboard, filter, attention, trust, login, installation, and freshness behavior to `docs/product-guide.md`.
- Moved local Worker modes, configuration, GitHub App secrets/webhooks, AI summaries, Cloudflare bindings, deployment, and monitoring to `docs/self-hosting.md`.
- Kept API response shapes and cache semantics in `docs/api.md`, and scheduler batching/retry/quota details in `docs/refresh-scheduler.md`.
- Dropped nothing as obsolete or unverifiable; details were relocated or linked to their existing authoritative docs.

## Verification

- `npm ci` — passed; 0 vulnerabilities.
- `GITHUB_TOKEN=<authenticated token> npm run build` — passed; built 92 projects. The first anonymous attempt hit GitHub's upstream rate limit, as expected for a real-data build.
- `npm run check:static` — passed: size guard, TypeScript/Svelte typecheck, Oxlint, Oxfmt, frontend/Worker builds, and 277 tests.
- README quick start — passed against `https://release.bar/api/steipete`; returned owner `steipete`, 60 repositories, and `cache: fresh` during verification.
- `npm run dev` plus `curl http://127.0.0.1:5173/` — HTTP 200.
- Local Wrangler Worker plus `/` and `/openapi.json` smoke — HTTP 200 on port 8799. Port 8787 was already occupied by an unrelated local process, so the identical Worker command was rerun with only the port changed.
- Remote Wrangler development, `wrangler secret put`, and `wrangler deploy` require live credentials or mutate infrastructure; their documented flags and command shapes were validated against Wrangler 4.118.0 `--help` instead.
- Quick-start API field access was transcribed to a temporary TypeScript file, typechecked with the repository toolchain, and removed.
- Every README/new-doc relative link resolves. Every external README URL and badge returned HTTP 200; badge SVGs contain no `invalid` or `not found` card.
- `autoreview --mode local` — clean; no accepted/actionable findings.
